### PR TITLE
320 known membership applicability

### DIFF
--- a/packages/proveit/linear_algebra/inner_products/hilbert_spaces.py
+++ b/packages/proveit/linear_algebra/inner_products/hilbert_spaces.py
@@ -17,11 +17,6 @@ class HilbertSpacesLiteral(Literal):
             latex_format=r'\textrm{HilbertSpaces}',
             styles=styles)
     
-    # Map Hilbert spaces to their known membership(s) within 
-    # HilbertSpaces.  Such a membership relation is the 
-    # indication that it is a Hilbert space.
-    known_spaces_memberships = dict() 
-        
     def membership_object(self, element):
         return HilbertSpacesMembership(element, self)
 
@@ -39,9 +34,10 @@ class HilbertSpacesLiteral(Literal):
         Given a vector expression, vec, yield any Hilbert spaces
         known to contain vec.
         '''
+        from . import HilbertSpaces
         from proveit.linear_algebra import VecSpaces
         for vec_space in VecSpaces.yield_known_vec_spaces(vec, field=Complex):
-            if vec_space in HilbertSpacesLiteral.known_spaces_memberships:
+            if InClass(vec_space, HilbertSpaces).proven():
                 # This vector space is already known to be an inner
                 # product space.
                 yield vec_space
@@ -100,8 +96,6 @@ class HilbertSpacesMembership(ClassMembership):
         Prove InnerProdSpaces and VecSpaces memberships as side-effects
         and also remember known HilbertSpaces memberships.
         '''
-        HilbertSpacesLiteral.known_spaces_memberships.setdefault(
-                self.element, set()).add(judgment)
         yield self.derive_inner_prod_spaces_membership
         yield self.derive_vec_spaces_membership
     

--- a/packages/proveit/linear_algebra/inner_products/inner_prod_spaces.py
+++ b/packages/proveit/linear_algebra/inner_products/inner_prod_spaces.py
@@ -31,12 +31,6 @@ class InnerProdSpaces(VecSpaces):
             latex_format=r'\textrm{InnerProdSpaces}',
             theory=__file__)
     
-    # Map vector spaces to their known membership(s) within 
-    # InnerProdSpaces(K) for some field K. Such a membership relation 
-    # is the indication that it is a vector space over the 
-    # corresponding field.
-    known_vec_spaces_memberships = dict() 
-        
     def __init__(self, field, *, styles=None, _operator=None):
         if _operator is None:
             _operator = InnerProdSpaces._operator_
@@ -63,9 +57,11 @@ class InnerProdSpaces(VecSpaces):
         will be raised.
         '''
         for vec_space in VecSpaces.yield_known_vec_spaces(vec, field=field):
-            if vec_space in InnerProdSpaces.known__vec_space_memberships:
-                # This vector space is already known to be an inner
-                # product space.
+            if (field is None and InClass.has_known_membership(
+                    vec_space, domain_type=InnerProdSpaces._operator_)):
+                yield vec_space
+            elif field is not None and (
+                    InClass(vec_space, InnerProdSpaces(field)).proven()):
                 yield vec_space
             else:
                 try:
@@ -126,8 +122,6 @@ class InnerProdSpacesMembership(ClassMembership):
         Prove VecSpaces membership as a side-effect and
         remember known InnerProdSpaces memberships.
         '''
-        InnerProdSpaces.known_vec_spaces_memberships.setdefault(
-                self.element, set()).add(judgment)
         yield self.derive_vec_spaces_membership
     
     @prover

--- a/packages/proveit/linear_algebra/linear_maps/lin_map.py
+++ b/packages/proveit/linear_algebra/linear_maps/lin_map.py
@@ -12,9 +12,6 @@ class LinMap(Function):
                          latex_format=r'\mathcal{L}',
                          theory=__file__)
 
-    # Map elements to their known memberships as linear maps.
-    known_memberships = dict()
-
     def __init__(self, from_vspace, to_vspace, *, styles=None):
         '''
         Denote the set of linear maps that map from and to the given
@@ -51,12 +48,6 @@ class LinMapMembership(SetMembership):
 
     def __init__(self, element, domain):
         SetMembership.__init__(self, element, domain)
-        
-    def side_effects(self, judgment):
-        LinMap.known_memberships.setdefault(
-                self.element, set()).add(judgment)
-        return # generator yielding nothing
-        yield
 
         
 class LinMapAdd(Operation):

--- a/packages/proveit/linear_algebra/matrices/matrix_space.py
+++ b/packages/proveit/linear_algebra/matrices/matrix_space.py
@@ -10,9 +10,6 @@ class MatrixSpace(Operation):
     '''
     _operator_ = Literal(string_format=r'MSpace', theory=__file__)
     
-    # Map elements to their known memberships in a matrix space.
-    known_memberships = dict()
-    
     def __init__(self, field, rows, columns, *, styles=None):
         '''
         Create F^{m x n} as the MatrixSpace for field F with
@@ -91,11 +88,4 @@ class MatrixSpaceMembership(SetMembership):
 
     def __init__(self, element, domain):
         SetMembership.__init__(self, element, domain)
-        
-    def side_effects(self, judgment):
-        MatrixSpace.known_memberships.setdefault(
-                self.element, set()).add(judgment)
-        return # generator yielding nothing
-        yield
-
 

--- a/packages/proveit/linear_algebra/vector_spaces.py
+++ b/packages/proveit/linear_algebra/vector_spaces.py
@@ -31,11 +31,6 @@ class VecSpaces(Function):
     # a known vector spaces (see 'yield_known_vec_spaces').
     default_field = Complex # appropriate in typical cases.
     
-    # Map vector spaces to their known membership(s) within 
-    # VecSpaces(K) for some field K. Such a membership relation is the 
-    # indication that it is a vector space over the corresponding field.
-    known_vec_spaces_memberships = dict() 
-        
     def __init__(self, field, *, styles=None, _operator=None):
         if _operator is None:
             _operator = VecSpaces._operator_
@@ -83,8 +78,8 @@ class VecSpaces(Function):
             # specified field.
             domain = membership.domain
             vec_space = None
-            if (field is None and 
-                    domain in VecSpaces.known_vec_spaces_memberships):
+            if (field is None and InClass.has_known_membership(
+                    domain, domain_type=VecSpaces._operator_)):
                 vec_space = domain
             elif (field is not None and
                       InClass(domain, VecSpaces(field)).proven()):
@@ -111,10 +106,9 @@ class VecSpaces(Function):
         '''
         Given a vector space, yield its known fields.
         '''
-        if vec_space in VecSpaces.known_vec_spaces_memberships:
-            judgments = VecSpaces.known_vec_spaces_memberships[vec_space]
-            for judgment in judgments:
-                yield judgment.expr.domain.field
+        for membership in InClass.yield_known_memberships(vec_space):
+            if isinstance(membership.domain, VecSpaces):
+                yield membership.domain.field
 
     @staticmethod
     def known_vec_space(vec, *, field=None):
@@ -216,15 +210,6 @@ class VecSpacesMembership(ClassMembership):
             raise TypeError("domain expected to be VecSpaces, not %s"
                             %domain.__class__)
         self.field = domain.field
-    
-    def side_effects(self, judgment):
-        '''
-        Remember known VecSpaces memberships.
-        '''
-        VecSpaces.known_vec_spaces_memberships.setdefault(
-                self.element, set()).add(judgment)
-        return # generator yielding nothing
-        yield
     
     def conclude(self):
         '''


### PR DESCRIPTION
This addresses Issue #320.  Sudhindu ran into this problem in which the behavior was impacted by changes of default assumptions (rather than being dictacted simply by the current default assumptions).  In the process, I simplified the code, consolidating the work of storing/retrieving known memberships within in_class.py.  That is, this is cleaner and nicer for the future.