### PR TITLE
324 mark usability bug

### DIFF
--- a/packages/proveit/_core_/proof.py
+++ b/packages/proveit/_core_/proof.py
@@ -1314,7 +1314,7 @@ class Theorem(Proof):
             # Propagate to dependents.
             to_process = set(self._meaning_data._dependents)
             processed = {self}
-            while len(to_process) > 1:
+            while len(to_process) > 0:
                 dep_proof = to_process.pop()
                 if dep_proof in processed: continue
                 if dep_proof._meaning_data._non_allowances is None:

--- a/packages/proveit/logic/sets/enumeration/_theory_nbs_/proofs/in_enumerated_set/allowed_presumptions.txt
+++ b/packages/proveit/logic/sets/enumeration/_theory_nbs_/proofs/in_enumerated_set/allowed_presumptions.txt
@@ -17,3 +17,4 @@ proveit.logic.booleans.disjunction.associate
 proveit.numbers.numerals.decimals.nat2
 proveit.numbers.numerals.decimals.tuple_len_2_typical_eq
 proveit.logic.sets.enumeration.fold
+proveit.numbers.number_sets.real_numbers.nat_within_real


### PR DESCRIPTION
I ran across this bug hiding in there.  After the fix, I made sure all of the theorem proof notebooks ran and just needed one allowed_presumptions.txt update.  Go ahead and take a look for your awareness, then it should be fine to pull this into master.