### PR TITLE
334 improper in set() notation when in class() needed

### DIFF
--- a/packages/proveit/_core_/_theory_storage.py
+++ b/packages/proveit/_core_/_theory_storage.py
@@ -452,7 +452,7 @@ class TheoryStorage:
                 # Remove proofs that depended upon the removed theorem.
                 # Note the use of (obj) hash_id instead of expr_id here!
                 StoredSpecialStmt.remove_dependency_proofs(
-                        self.theory, kind, hash_id)
+                        self.theory, kind, old_name_to_expr_hash_id[name])
 
         # Now we write the new name-to-hash information.
         names = definitions.keys()

--- a/packages/proveit/logic/sets/membership/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/logic/sets/membership/_theory_nbs_/demonstrations.ipynb
@@ -18,10 +18,11 @@
     "from proveit import ExprTuple, InstantiationFailure, ProofFailure, UnsatisfiedPrerequisites\n",
     "from proveit.logic import (Forall, Equals, EvaluationError, InSet, Not, NotEquals,\n",
     "                           NotInSet, EmptySet, Set)\n",
-    "from proveit import a, b, c, d, e, f, i, x, y, A, B, C, D, E, F, G, H, I, S, T\n",
+    "from proveit import a, b, c, d, e, f, i, x, y, A, B, C, D, E, F, G, H, I, S, T, V\n",
     "from proveit.numbers import zero, one, two, three, four, five, six, seven, eight, nine, num, Exp\n",
     "from proveit.numbers import Add, Integer, Mult, Natural, NaturalPos, Real, RealNeg, RealPos\n",
     "from proveit.numbers.number_sets.number_set import NumberSet\n",
+    "from proveit.linear_algebra import VecSpaces\n",
     "%begin demonstrations"
    ]
   },
@@ -267,6 +268,80 @@
    "source": [
     "## Miscellaneous Testing\n",
     "The material below was developed to test various membership-related methods. Some of this material could be integrated into the `demonstrations` page eventually and/or deleted as development continues."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Testing the `InSet` constructor\n",
+    "\n",
+    "The `InSet` constructor should catch constructions that should be `InClass()` instead of `InSet()`. Then collection of all vector spaces `VecSpaces(F)` over a field `F`, for example, is a proper class instead of a set, and it would be good to avoid expressions such as $V \\in \\mathrm{VecSpaces}(\\mathbb{R})$, instead substituting the correct in-class notation $V \\underset{{\\scriptscriptstyle c}}{\\in} \\mathrm{VecSpaces}(\\mathbb{R})$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The real numbers $\\mathbb{R}$ constitute a valid set (instead of a proper class), and we can construct a membership expression using either `InClass` or the more specific `InSet`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit.logic import InClass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "in_set_example, in_class_example = (InSet(x, Real), InClass(x, Real))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But the class `VecSpaces(Real)` of all vector spaces over the field of real numbers $\\mathbb{R}$ requires the `InClass` construction, and has the `is_proper_class` property attribute that can be checked:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if VecSpaces.is_proper_class:\n",
+    "    print(f\"VecSpaces IS a proper class!\")\n",
+    "else:\n",
+    "    print(f\"VecSpaces is NOT a proper class!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "InClass(V, VecSpaces(Real))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    failing_in_set_example = InSet(V, VecSpaces(Real))\n",
+    "except ValueError as the_error:\n",
+    "    print(f\"Exception: {the_error}\")"
    ]
   },
   {

--- a/packages/proveit/logic/sets/membership/in_set.py
+++ b/packages/proveit/logic/sets/membership/in_set.py
@@ -20,6 +20,12 @@ class InSet(InClass):
     def __init__(self, element, domain, *, styles=None):
         element = single_or_composite_expression(element)
         domain = single_or_composite_expression(domain)
+        if (hasattr(domain, 'is_proper_class') and domain.is_proper_class):
+            raise ValueError(
+                    f"The domain {domain} is a proper class (as specified "
+                    f"by its 'is_proper_class' attribute) and thus "
+                    f"should use the 'InClass()' constructor instead "
+                    f"of the 'InSet()' constructor.")
         InSet.inset_expressions[(element, domain)] = self
         InClass.__init__(self, element, domain, operator=InSet._operator_,
                          styles=styles)


### PR DESCRIPTION
This pull request involves two simple changes that will:

1. Augment the `InSet.__init__()` constructor method to raise a `ValueError` for cases that should use `InClass()` instead of `InSet()`;
2. Fix a bug in `_theory_storage.py` in which 'hash_id' was being used before it was defined. See related emails between WW and wdc on 4/24/2025.

Edits also include minor updates to the related sets/membership demonstrations.ipynb notebook to include related testing/examples.
The modified code allows `build_alt.py --essential` to run to completion without errors.