### PR TITLE
Updated SubsetEq.conclude() to better accommodate basic SetOfAll()

### DIFF
--- a/packages/proveit/logic/sets/comprehension/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/logic/sets/comprehension/_theory_nbs_/demonstrations.ipynb
@@ -140,6 +140,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "squares_of_unit_interval.explicit_conditions()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "positive_reals.conditions"
    ]
   },

--- a/packages/proveit/logic/sets/inclusion/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/logic/sets/inclusion/_theory_nbs_/demonstrations.ipynb
@@ -16,20 +16,21 @@
    "source": [
     "import proveit\n",
     "from proveit import free_vars, InstantiationFailure, ProofFailure, used_vars\n",
-    "from proveit import a, b, c, d, e, f, x, y, A, B, C, D, E, F, X, Y, Px\n",
+    "from proveit import a, b, c, d, e, f, x, y, z, A, B, C, D, E, F, X, Y, Px\n",
     "from proveit.logic import (Equals, Forall, Exists, Implies, InSet, Not,\n",
     "                           NotEquals, NotInSet, Set)\n",
     "from proveit.logic import (Intersect, SetEquiv, NotProperSubset,\n",
-    "                           SubsetEq, NotSubsetEq, not_superset_eq,\n",
-    "                           ProperSubset, proper_superset, not_proper_superset,\n",
-    "                           SubsetProper, StrictSubset, superset_eq)\n",
-    "from proveit.numbers import zero, one, two, three, four, five\n",
+    "                           SubsetEq, NotEquals, NotSubsetEq, not_superset_eq,\n",
+    "                           Or, ProperSubset, proper_superset, not_proper_superset,\n",
+    "                           SetOfAll, SubsetProper, StrictSubset, superset_eq)\n",
+    "from proveit.numbers import zero, one, two, three, four, five, greater, Less, LessEq, num\n",
     "from proveit.numbers import (Integer, Natural, NaturalPos, Real,\n",
     "                            RealNeg, RealPos)\n",
     "from proveit.numbers.number_sets.real_numbers import int_within_real\n",
     "from proveit.logic.sets.inclusion  import (\n",
     "        subset_eq_def, proper_subset_def, not_proper_subset_def, unfold_not_subset_eq)\n",
     "from proveit.logic.sets.inclusion import fold_not_subset_eq, fold_subset_eq\n",
+    "\n",
     "%begin demonstrations"
    ]
   },
@@ -1862,15 +1863,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# Some issue here involving SetOfAll sets;\n",
-    "# the set_of_all.py and sets/comprehension package must be updated\n",
-    "# from proveit.logic import NotEquals, SetOfAll\n",
-    "# non_zero_ints = SetOfAll(x, x, conditions=[NotEquals(x, zero)], domain=Integer)"
+    "#### `SubsetEq().conclude()` Examples Involving `SetOfAll()` Constructions"
    ]
   },
   {
@@ -1879,9 +1875,88 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Some issue here involving SetOfAll sets;\n",
-    "# the set_of_all.py and sets/comprehension package must be updated\n",
-    "# SubsetEq(non_zero_ints, Integer).conclude()"
+    "non_zero_ints = SetOfAll(x, x, conditions=[NotEquals(x, zero)], domain=Integer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SubsetEq(non_zero_ints, Integer).conclude()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ints_1_thru_9 = SetOfAll(x, x, conditions=[LessEq(one, x), LessEq(x, num(9))], domain=Integer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SubsetEq(ints_1_thru_9, Integer).conclude()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_the_ints = SetOfAll(x, x, domain=Integer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SubsetEq(all_the_ints, Integer).conclude()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pos_100_z = SetOfAll(z, z, conditions = [greater(z, zero), LessEq(z, num(100))], domain = Integer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SubsetEq(pos_100_z, Integer).conclude()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "non_zero_z_using_or = SetOfAll(z, z, conditions = [Or(Less(z, zero), greater(z, zero))], domain = Integer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SubsetEq(non_zero_z_using_or, Integer).conclude()"
    ]
   },
   {


### PR DESCRIPTION
This branch updates the `SubsetEq.conclude()` method (in logic/sets/inclusion) to deal more correctly with the special case of "basic" `SetOfAll` set comprehensions. Some errors had recently been encountered due to some older code in the conclude() method. The use of `SetOfAll.explicit_conditions()` (instead of the more general .conditions()) and wrapping conditions in a logical `And()` seems to have corrected the most basic problems. Branch also includes updated related demonstrations notebook in logic/sets/inclusion and minor addition to demonstrations notebook in logic/sets/comprehension.