### PR TITLE
Issue 374 Correct bug in Abs._deduce_canonically_equal() method

### DIFF
--- a/packages/proveit/numbers/absolute_value/abs.py
+++ b/packages/proveit/numbers/absolute_value/abs.py
@@ -44,7 +44,7 @@ class Abs(NumberOperation):
         from proveit.logic import Equals
         assert isinstance(rhs, Abs)
         operand_cf = self.operand.canonical_form()
-        rhs_operand_cf = rhs.canonical_form()
+        rhs_operand_cf = rhs.operand.canonical_form()
         if operand_cf == rhs_operand_cf:
             # Prove equality using standard techniques.
             return NumberOperation._deduce_canonically_equal(self, rhs)


### PR DESCRIPTION
Correct a bug in the Abs()._deduce_canonically_equal() method, now looking at the operand of an Abs (absolute value) object instead of the Abs itself. See Issue #374 .