### PR TITLE
Update ClassMembership.shallow_simplification() method

### DIFF
--- a/packages/proveit/classes/class_membership.py
+++ b/packages/proveit/classes/class_membership.py
@@ -320,7 +320,9 @@ class ClassMembership(Operation):
         try:
             definition = self.definition()
         except NotImplementedError:
-            # Don't know what to do otherwise.
+            definition = None
+        if definition is None or (definition.lhs == definition.rhs):
+            # definition failed or is trivial
             return Operation.shallow_simplification(
                     self, must_evaluate=must_evaluate)
         try:


### PR DESCRIPTION
This branch updates ClassMembership.shallow_simplification() method to include a check for when the membership.definition() returns a trivial `self=self` equality.