### PR TITLE
380 utilize vacuous interval theorem

### DIFF
--- a/packages/proveit/logic/booleans/quantification/existence/exists.py
+++ b/packages/proveit/logic/booleans/quantification/existence/exists.py
@@ -82,6 +82,10 @@ class Exists(OperationOverInstances):
         '''
         Side-effect derivations to attempt automatically for an exists operations.
         '''
+        if hasattr(self.instance_expr, 'existential_side_effects'):
+            for side_effect in (
+                    self.instance_expr.existential_side_effects(judgment)):
+                yield side_effect
         return
         yield self.derive_negated_forall  # derive the negated forall form
 

--- a/packages/proveit/logic/equality/not_equals.py
+++ b/packages/proveit/logic/equality/not_equals.py
@@ -28,6 +28,9 @@ class NotEquals(Relation):
         if self.rhs == FALSE:
             yield self.derive_via_double_negation  # A from A != False and A in Boolean
         yield self.unfold  # Not(x=y) from x != y
+        if hasattr(self.rhs, 'not_equals_side_effects'):
+            for side_effect in self.rhs.not_equals_side_effects(judgment):
+                yield side_effect
 
     def _readily_provable(self, try_readily_not_equal=True):
         '''

--- a/packages/proveit/logic/sets/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/logic/sets/_theory_nbs_/demonstrations.ipynb
@@ -181,6 +181,46 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Testing related to `EmptySet.not_equals_side_effects()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit import x\n",
+    "from proveit.logic import Exists, NotEquals\n",
+    "Exists(x, InSet(x, A)).prove(assumptions=[NotEquals(A, EmptySet)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit import y\n",
+    "from proveit.logic import Exists, NotEquals\n",
+    "Exists(y, InSet(y, A)).prove(assumptions=[NotEquals(A, EmptySet)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit import z\n",
+    "from proveit.logic import Exists, NotEquals\n",
+    "Exists(z, InSet(z, A)).prove(assumptions=[NotEquals(EmptySet, A)])"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/packages/proveit/logic/sets/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/logic/sets/_theory_nbs_/demonstrations.ipynb
@@ -15,7 +15,25 @@
    "outputs": [],
    "source": [
     "import proveit\n",
+    "from proveit import x, y, A\n",
+    "from proveit.logic import Implies\n",
+    "from proveit.logic.sets import EmptySet, InSet, NotInSet\n",
+    "\n",
     "%begin demonstrations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Misc. Constructions and Testing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### `EmptySet`, `EmptySetMembership` and `EmptySetNonmembership` Constructions"
    ]
   },
   {
@@ -23,7 +41,144 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "EmptySet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "InSet(x, EmptySet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NotInSet(y, EmptySet)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Basic `EmptySetMembership` and `EmptySetNonmembership` Methods"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "InSet(x, EmptySet).deduce_in_bool()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NotInSet(y, EmptySet).deduce_in_bool()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "InSet(y, EmptySet)._readily_provable()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "InSet(x, EmptySet)._readily_disprovable()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NotInSet(y, EmptySet).conclude()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "InSet(x, EmptySet).derive_contradiction(assumptions = [InSet(x, EmptySet)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "claim_to_deny = A\n",
+    "bad_impl = Implies(claim_to_deny, InSet(x, EmptySet))\n",
+    "InSet(x, EmptySet).deny_via_contradiction(A, assumptions=[bad_impl])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit.logic import in_bool, Not\n",
+    "claim_to_affirm = A\n",
+    "bad_impl = Implies(Not(claim_to_affirm), InSet(x, EmptySet))\n",
+    "InSet(x, EmptySet).affirm_via_contradiction(A, assumptions=[bad_impl, in_bool(A)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Perhaps the affirm_via_contradiction() and deny_via_contradiction() methods shown above makes more sense as more general functions rather than EmptySetMembership methods? a method for the EmptySetNonmembership? The methods seems out of place there and counter-intuitive, almost as if we'd want to call such methods on an implication such as $A \\Rightarrow (x \\in \\emptyset)$ instead. We might just want a general function like deny_via_empty_set_contradiction(A, elem=None, …), as a general function defined in the $\\text{empty\\_set\\_membership.py}$ code?\n",
+    "\n",
+    "That approach is illustrated below, importing and executing the `affirm_via_empty_set_contradiction()` and `deny_via_empty_set_contradiction()` functions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "claim_to_affirm = A\n",
+    "bad_impl = Implies(Not(claim_to_affirm), InSet(y, EmptySet))\n",
+    "from proveit.logic.sets.empty_set_membership import affirm_via_empty_set_contradiction\n",
+    "affirm_via_empty_set_contradiction(claim_to_affirm, elem = y, assumptions=[bad_impl, in_bool(A)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "claim_to_deny = A\n",
+    "bad_impl = Implies(claim_to_deny, InSet(y, EmptySet))\n",
+    "from proveit.logic.sets.empty_set_membership import deny_via_empty_set_contradiction\n",
+    "deny_via_empty_set_contradiction(claim_to_deny, elem = y, assumptions=[bad_impl, in_bool(A)])"
+   ]
   },
   {
    "cell_type": "code",

--- a/packages/proveit/logic/sets/_theory_nbs_/proofs/empty_set_contradiction/thm_proof.ipynb
+++ b/packages/proveit/logic/sets/_theory_nbs_/proofs/empty_set_contradiction/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">logic</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">sets</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#empty_set_contradiction\">empty_set_contradiction</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving empty_set_contradiction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/logic/sets/_theory_nbs_/proofs/empty_set_membership_is_bool/thm_proof.ipynb
+++ b/packages/proveit/logic/sets/_theory_nbs_/proofs/empty_set_membership_is_bool/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">logic</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">sets</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#empty_set_membership_is_bool\">empty_set_membership_is_bool</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving empty_set_membership_is_bool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/logic/sets/_theory_nbs_/proofs/empty_set_nonmembership_is_bool/thm_proof.ipynb
+++ b/packages/proveit/logic/sets/_theory_nbs_/proofs/empty_set_nonmembership_is_bool/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">logic</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">sets</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#empty_set_nonmembership_is_bool\">empty_set_nonmembership_is_bool</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving empty_set_nonmembership_is_bool"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/logic/sets/_theory_nbs_/proofs/non_empty_def/thm_proof.ipynb
+++ b/packages/proveit/logic/sets/_theory_nbs_/proofs/non_empty_def/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">logic</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">sets</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#non_empty_def\">non_empty_def</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving non_empty_def"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/logic/sets/_theory_nbs_/proofs/non_empty_folding/thm_proof.ipynb
+++ b/packages/proveit/logic/sets/_theory_nbs_/proofs/non_empty_folding/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">logic</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">sets</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#non_empty_folding\">non_empty_folding</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving non_empty_folding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/logic/sets/_theory_nbs_/proofs/non_empty_unfolding/thm_proof.ipynb
+++ b/packages/proveit/logic/sets/_theory_nbs_/proofs/non_empty_unfolding/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">logic</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">sets</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#non_empty_unfolding\">non_empty_unfolding</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving non_empty_unfolding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/logic/sets/_theory_nbs_/theorems.ipynb
+++ b/packages/proveit/logic/sets/_theory_nbs_/theorems.ipynb
@@ -18,8 +18,8 @@
     "# Prepare this notebook for defining the theorems of a theory:\n",
     "%theorems_notebook # Keep this at the top following 'import proveit'.\n",
     "from proveit import n, x, A, B, S\n",
-    "from proveit.logic import (Boolean, Card, EmptySet, Equals,\n",
-    "                           Exists, Forall, in_bool, Intersect, InSet, NotInSet)\n",
+    "from proveit.logic import (Boolean, Card, EmptySet, Equals, Exists, FALSE,\n",
+    "                           Forall, in_bool, Intersect, InSet, NotEquals, NotInSet)\n",
     "from proveit.logic import And, SetEquiv, SubsetEq, Union\n",
     "from proveit.numbers import one, greater_eq, LessEq, Natural\n",
     "\n",
@@ -40,6 +40,45 @@
    "outputs": [],
    "source": [
     "nothing_is_in_empty = Forall(x, NotInSet(x, EmptySet))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "empty_set_contradiction = Forall(x, FALSE, conditions=[InSet(x, EmptySet)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "non_empty_def = (\n",
+    "    Forall(A, Equals(NotEquals(A, EmptySet), Exists(x, InSet(x, A)))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "non_empty_unfolding = (\n",
+    "Forall(A, Exists(x, InSet(x, A)), conditions=[NotEquals(A, EmptySet)]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "non_empty_folding = (\n",
+    "Forall(A, NotEquals(A, EmptySet), conditions=[Exists(x, InSet(x, A))]))"
    ]
   },
   {

--- a/packages/proveit/logic/sets/_theory_nbs_/theorems.ipynb
+++ b/packages/proveit/logic/sets/_theory_nbs_/theorems.ipynb
@@ -19,7 +19,7 @@
     "%theorems_notebook # Keep this at the top following 'import proveit'.\n",
     "from proveit import n, x, A, B, S\n",
     "from proveit.logic import (Boolean, Card, EmptySet, Equals,\n",
-    "                           Exists, Forall, Intersect, InSet, NotInSet)\n",
+    "                           Exists, Forall, in_bool, Intersect, InSet, NotInSet)\n",
     "from proveit.logic import And, SetEquiv, SubsetEq, Union\n",
     "from proveit.numbers import one, greater_eq, LessEq, Natural\n",
     "\n",
@@ -40,6 +40,31 @@
    "outputs": [],
    "source": [
     "nothing_is_in_empty = Forall(x, NotInSet(x, EmptySet))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Boolean Claims"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "empty_set_membership_is_bool = Forall(x, in_bool(InSet(x, EmptySet)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "empty_set_nonmembership_is_bool = Forall(x, in_bool(NotInSet(x, EmptySet)))"
    ]
   },
   {

--- a/packages/proveit/logic/sets/empty_set.py
+++ b/packages/proveit/logic/sets/empty_set.py
@@ -3,7 +3,22 @@ from proveit.logic.irreducible_value import IrreducibleValue
 
 
 class EmptySetLiteral(Literal, IrreducibleValue):
+    '''
+    EmptySet represents the standard empty set, which has no elements.
+    EmptySet is then defined in the logic/sets common notebook as
+    EmptySet = EmptySetLiteral(), so one can import and use 'EmptySet'
+    itself.
+    '''
+
     def __init__(self, *, styles=None):
         Literal.__init__(
             self, string_format='emptyset', latex_format=r'\emptyset',
             styles=styles)
+
+    def membership_object(self, element):
+        from .empty_set_membership import EmptySetMembership
+        return EmptySetMembership(element, self)
+
+    def nonmembership_object(self, element):
+        from .empty_set_membership import EmptySetNonmembership
+        return EmptySetNonmembership(element, self)

--- a/packages/proveit/logic/sets/empty_set.py
+++ b/packages/proveit/logic/sets/empty_set.py
@@ -1,4 +1,5 @@
-from proveit import Literal
+from proveit import A, Judgment, Literal
+from proveit.logic import NotEquals
 from proveit.logic.irreducible_value import IrreducibleValue
 
 
@@ -22,3 +23,34 @@ class EmptySetLiteral(Literal, IrreducibleValue):
     def nonmembership_object(self, element):
         from .empty_set_membership import EmptySetNonmembership
         return EmptySetNonmembership(element, self)
+
+    def not_equals_side_effects(self, judgment):
+        '''
+        For a judgment or assumption of the form A ≠ EmptySet,
+        derive the existential Judgment:
+
+          |- Exists_{x} [x in A]
+
+        (i.e., if A is not empty, there must exist an element in A).
+        This side-effect method is called from NotEquals.side_effects().
+        '''
+
+        from . import EmptySet
+        if not isinstance(judgment, Judgment):
+            raise ValueError(
+                    "EmptySet.not_equals_side_effects() expecting 'judgment' "
+                    f"argument to be Judgment but got {judgment}.")
+        if not isinstance(judgment.expr, NotEquals):
+            raise ValueError(
+                    "EmptySet.not_equals_side_effects() expecting "
+                    "'judgment' argument to be an inequality Judgment "
+                    f"but got {judgment}.")
+        if not isinstance(judgment.rhs, EmptySetLiteral):
+            raise ValueError(
+                    "EmptySet.not_equals_side_effects() expecting "
+                    "'judgment' argument have rhs be EmptySet, "
+                    f"but got {judgment.rhs}.")
+        from proveit.logic.sets import non_empty_unfolding
+        _A_sub = judgment.lhs
+        yield (lambda : non_empty_unfolding.instantiate({A:_A_sub}))
+

--- a/packages/proveit/logic/sets/empty_set_membership.py
+++ b/packages/proveit/logic/sets/empty_set_membership.py
@@ -1,0 +1,167 @@
+from proveit import x, prover
+from proveit.logic import SetMembership, SetNonmembership
+
+class EmptySetMembership(SetMembership):
+    '''
+    Defines methods that apply to membership in the empty set
+    (EmptySet). Technically, nothing is a member of the empty set;
+    thus deductions to the contrary allow us to disprove assumptions
+    that lead to such a deduction, and an empty set membership
+    assumption should allow us to conclude anything.
+    '''
+
+    def __init__(self, element, domain):
+        SetMembership.__init__(self, element, domain)
+
+    # def side_effects(self, judgment):
+    #     '''
+    #     Unfold the enumerated set membership as a side-effect.
+    #     '''
+    #     yield self.unfold
+
+    # @equality_prover('defined', 'define')
+    # def definition(self, **defaults_config):
+    #     '''
+    #     Deduce and return 
+    #         [element in (A union B ...)] = 
+    #         [(element in A) or (element in B) ...]
+    #     where self = (A union B ...).
+    #     '''
+    #     from . import union_def
+    #     element = self.element
+    #     operands = self.domain.operands
+    #     _A = operands
+    #     _m = _A.num_elements()
+    #     return union_def.instantiate(
+    #             {m: _m, x: element, A: _A}, auto_simplify=False)
+
+    # def as_defined(self):
+    #     '''
+    #     From self=[elem in (A U B U ...)], return
+    #     [(element in A) or (element in B) or ...].
+    #     '''
+    #     from proveit.logic import Or, InSet
+    #     element = self.element
+    #     return Or(*self.domain.operands.map_elements(
+    #             lambda subset : InSet(element, subset)))
+
+    # @prover
+    # def unfold(self, **defaults_config):
+    #     '''
+    #     From [element in (A union B ...)], derive and return
+    #     [(element in A) or (element in B) ...],
+    #     where self represents [element in (A union B ...)].
+    #     '''
+    #     from . import membership_unfolding
+    #     element = self.element
+    #     operands = self.domain.operands
+    #     _A = operands
+    #     _m = _A.num_elements()
+    #     return membership_unfolding.instantiate(
+    #         {m: _m, x: element, A: _A}, auto_simplify=False)
+
+    # @prover
+    # def conclude(self, **defaults_config):
+    #     '''
+    #     Called on self = [elem in (A U B U ...)], and knowing or
+    #     assuming [[elem in A] OR [elem in B] OR ...], derive and
+    #     return self.
+    #     '''
+    #     from . import membership_folding
+    #     element = self.element
+    #     operands = self.domain.operands
+    #     _A = operands
+    #     _m = _A.num_elements()
+    #     return membership_folding.instantiate({m: _m, x: element, A: _A})
+
+    @prover
+    def derive_contradiction(self, **defaults_config):
+        r'''
+        From self = [x in EmptySet], derive and return FALSE.
+        '''
+        from . import empty_set_contradiction
+        _x_sub = self.element
+        return empty_set_contradiction.instantiate({x: _x_sub})
+
+    @prover
+    def deny_via_contradiction(self, conclusion, **defaults_config):
+        '''
+        From self = x in EmptySet, derive the negated conclusion,
+        provided that the conclusion implies x in EmptySet (because
+        x in EmptySet should never be true).
+        '''
+        print(f"Entering EmptySetMembership.deny_via_contradiction() with:")
+        print(f"    self = {self}")
+        display(self)
+        from proveit.logic.booleans.implication import deny_via_contradiction
+        return deny_via_contradiction(self.expr, conclusion)
+
+    def readily_in_bool(self):
+        return True # EmptySetMembership is always boolean
+
+    @prover
+    def deduce_in_bool(self, **defaults_config):
+        from . import empty_set_membership_is_bool
+        _x_sub = self.element
+        return empty_set_membership_is_bool.instantiate({x: _x_sub})
+
+
+class EmptySetNonmembership(SetNonmembership):
+    '''
+    Defines methods that apply to non-membership in the empty set
+    (EmptySet).
+    UNDER CONSTRUCTION
+    '''
+
+    def __init__(self, element, domain):
+        SetNonmembership.__init__(self, element, domain)
+        self.domain = domain
+
+    # def _readily_provable(self):
+    #     '''
+    #     The Nonmembership is readily provabile if the element
+    #     is readily known to be a non-integer or its readily known to be 
+    #     below/above the lower/upper bound.
+    #     '''
+    #     _a = self.domain.lower_bound
+    #     _b = self.domain.upper_bound
+    #     _x = self.element
+    #     return InSet(_x, Integer).readily_disprovable() or (
+    #             Less(_x, _a).readily_provable() or
+    #             Less(_b, _x).readily_provable())
+
+    # def side_effects(self, judgment):
+    #     '''
+    #     Yield some possible side effects of Interval set nonmembership:
+    #     (1) if element is an integer, deduce some possible bounds on it;
+    #     '''
+    #     if InSet(self.element, Integer).readily_provable():
+    #         yield self.deduce_int_element_bounds
+
+    # @prover
+    # def conclude(self, **defaults_config):
+    #     '''
+    #     From x not in Integers, or an integer x such that x < a or x > b,
+    #     derive and return [element x not in Interval(a, b)],
+    #     where self is the IntervalNonmembership object.
+    #     '''
+    #     _a = self.domain.lower_bound
+    #     _b = self.domain.upper_bound
+    #     _x = self.element
+    #     if InSet(self.element, Integer).readily_provable():
+    #         from . import int_not_in_interval
+    #         return int_not_in_interval.instantiate(
+    #                 {a: _a, b: _b, x: _x})
+    #     else:
+    #         from . import not_int_not_in_interval
+    #         return not_int_not_in_interval.instantiate(
+    #                 {a: _a, b: _b, x: _x})
+
+    def readily_in_bool(self):
+        return True # EmptySetNonmembership is always boolean
+
+    @prover
+    def deduce_in_bool(self, **defaults_config):
+        from . import empty_set_nonmembership_is_bool
+        _x_sub = self.element
+        return empty_set_nonmembership_is_bool.instantiate({x: _x_sub})

--- a/packages/proveit/logic/sets/empty_set_membership.py
+++ b/packages/proveit/logic/sets/empty_set_membership.py
@@ -1,4 +1,4 @@
-from proveit import x, prover
+from proveit import x, defaults, prover
 from proveit.logic import SetMembership, SetNonmembership
 
 class EmptySetMembership(SetMembership):
@@ -13,66 +13,20 @@ class EmptySetMembership(SetMembership):
     def __init__(self, element, domain):
         SetMembership.__init__(self, element, domain)
 
-    # def side_effects(self, judgment):
-    #     '''
-    #     Unfold the enumerated set membership as a side-effect.
-    #     '''
-    #     yield self.unfold
+    def _readily_provable(self):
+        '''
+        Membership in the empty set is always FALSE, and thus is
+        never readily provable, regardless of the element in question.
+        '''
+        return False
 
-    # @equality_prover('defined', 'define')
-    # def definition(self, **defaults_config):
-    #     '''
-    #     Deduce and return 
-    #         [element in (A union B ...)] = 
-    #         [(element in A) or (element in B) ...]
-    #     where self = (A union B ...).
-    #     '''
-    #     from . import union_def
-    #     element = self.element
-    #     operands = self.domain.operands
-    #     _A = operands
-    #     _m = _A.num_elements()
-    #     return union_def.instantiate(
-    #             {m: _m, x: element, A: _A}, auto_simplify=False)
-
-    # def as_defined(self):
-    #     '''
-    #     From self=[elem in (A U B U ...)], return
-    #     [(element in A) or (element in B) or ...].
-    #     '''
-    #     from proveit.logic import Or, InSet
-    #     element = self.element
-    #     return Or(*self.domain.operands.map_elements(
-    #             lambda subset : InSet(element, subset)))
-
-    # @prover
-    # def unfold(self, **defaults_config):
-    #     '''
-    #     From [element in (A union B ...)], derive and return
-    #     [(element in A) or (element in B) ...],
-    #     where self represents [element in (A union B ...)].
-    #     '''
-    #     from . import membership_unfolding
-    #     element = self.element
-    #     operands = self.domain.operands
-    #     _A = operands
-    #     _m = _A.num_elements()
-    #     return membership_unfolding.instantiate(
-    #         {m: _m, x: element, A: _A}, auto_simplify=False)
-
-    # @prover
-    # def conclude(self, **defaults_config):
-    #     '''
-    #     Called on self = [elem in (A U B U ...)], and knowing or
-    #     assuming [[elem in A] OR [elem in B] OR ...], derive and
-    #     return self.
-    #     '''
-    #     from . import membership_folding
-    #     element = self.element
-    #     operands = self.domain.operands
-    #     _A = operands
-    #     _m = _A.num_elements()
-    #     return membership_folding.instantiate({m: _m, x: element, A: _A})
+    def _readily_disprovable(self):
+        '''
+        Membership in the empty set is always FALSE, and thus is
+        always readily disprovable, regardless of the element in
+        question.
+        '''
+        return True
 
     @prover
     def derive_contradiction(self, **defaults_config):
@@ -84,15 +38,22 @@ class EmptySetMembership(SetMembership):
         return empty_set_contradiction.instantiate({x: _x_sub})
 
     @prover
+    def affirm_via_contradiction(self, conclusion, **defaults_config):
+        '''
+        From self = [x in EmptySet], derive conclusion, provided that
+        the negation of conclusion implies [x in EmptySet] (because
+        [x in EmptySet] should never be true).
+        '''
+        from proveit.logic.booleans.implication import affirm_via_contradiction
+        return affirm_via_contradiction(self.expr, conclusion)
+
+    @prover
     def deny_via_contradiction(self, conclusion, **defaults_config):
         '''
         From self = x in EmptySet, derive the negated conclusion,
         provided that the conclusion implies x in EmptySet (because
         x in EmptySet should never be true).
         '''
-        print(f"Entering EmptySetMembership.deny_via_contradiction() with:")
-        print(f"    self = {self}")
-        display(self)
         from proveit.logic.booleans.implication import deny_via_contradiction
         return deny_via_contradiction(self.expr, conclusion)
 
@@ -109,53 +70,38 @@ class EmptySetMembership(SetMembership):
 class EmptySetNonmembership(SetNonmembership):
     '''
     Defines methods that apply to non-membership in the empty set
-    (EmptySet).
-    UNDER CONSTRUCTION
+    (EmptySet). Non-membership, i.e., x NotIn EmptySet, is always
+    TRUE.
     '''
 
     def __init__(self, element, domain):
         SetNonmembership.__init__(self, element, domain)
         self.domain = domain
 
-    # def _readily_provable(self):
-    #     '''
-    #     The Nonmembership is readily provabile if the element
-    #     is readily known to be a non-integer or its readily known to be 
-    #     below/above the lower/upper bound.
-    #     '''
-    #     _a = self.domain.lower_bound
-    #     _b = self.domain.upper_bound
-    #     _x = self.element
-    #     return InSet(_x, Integer).readily_disprovable() or (
-    #             Less(_x, _a).readily_provable() or
-    #             Less(_b, _x).readily_provable())
+    def _readily_provable(self):
+        '''
+        The Nonmembership is always TRUE, and thus is always readily
+        provable, regardless of the element in question.
+        '''
+        return True
 
-    # def side_effects(self, judgment):
-    #     '''
-    #     Yield some possible side effects of Interval set nonmembership:
-    #     (1) if element is an integer, deduce some possible bounds on it;
-    #     '''
-    #     if InSet(self.element, Integer).readily_provable():
-    #         yield self.deduce_int_element_bounds
+    def _readily_disprovable(self):
+        '''
+        The Nonmembership is always TRUE, and thus is never readily
+        disprovable, regardless of the element in question.
+        '''
+        return False
 
-    # @prover
-    # def conclude(self, **defaults_config):
-    #     '''
-    #     From x not in Integers, or an integer x such that x < a or x > b,
-    #     derive and return [element x not in Interval(a, b)],
-    #     where self is the IntervalNonmembership object.
-    #     '''
-    #     _a = self.domain.lower_bound
-    #     _b = self.domain.upper_bound
-    #     _x = self.element
-    #     if InSet(self.element, Integer).readily_provable():
-    #         from . import int_not_in_interval
-    #         return int_not_in_interval.instantiate(
-    #                 {a: _a, b: _b, x: _x})
-    #     else:
-    #         from . import not_int_not_in_interval
-    #         return not_int_not_in_interval.instantiate(
-    #                 {a: _a, b: _b, x: _x})
+    @prover
+    def conclude(self, **defaults_config):
+        '''
+        Empty set non-membership is always True, regardless of the
+        element being considered. From self = [elem NotIn EmptySet],
+        return |- [elem Notin EmptySet].
+        '''
+        from proveit.logic.sets import nothing_is_in_empty
+        _x_sub = self.element
+        return nothing_is_in_empty.instantiate({x: _x_sub})
 
     def readily_in_bool(self):
         return True # EmptySetNonmembership is always boolean
@@ -165,3 +111,42 @@ class EmptySetNonmembership(SetNonmembership):
         from . import empty_set_nonmembership_is_bool
         _x_sub = self.element
         return empty_set_nonmembership_is_bool.instantiate({x: _x_sub})
+
+# General Functions Related to Empty Set Membership
+
+@prover
+def affirm_via_empty_set_contradiction(
+        claim_to_affirm, elem = None, **defaults_config):
+    '''
+    Derive and return the 'claim_to_affirm', provided
+    that (1) claim_to_affirm is Boolean and (2) the negation of
+    claim_to_affirm implies [elem in EmptySet] (because x in EmptySet
+    is FALSE for all x).
+    '''
+    from . import empty_set_contradiction
+    from proveit.logic import Not
+    if elem is None: elem = x
+    extended_assumptions = defaults.assumptions + (Not(claim_to_affirm),)
+    contradiction = empty_set_contradiction.instantiate(
+            {x:elem}, assumptions = extended_assumptions)
+    contradiction_as_impl = contradiction.as_implication(Not(claim_to_affirm))
+    return contradiction_as_impl.deny_antecedent(
+            assumptions = extended_assumptions)
+
+@prover
+def deny_via_empty_set_contradiction(
+        claim_to_deny, elem = None, **defaults_config):
+    '''
+    Derive and return the negation of the 'claim_to_deny', provided
+    that (1) claim_to_deny is Boolean and (2) claim_to_deny implies
+    [elem in EmptySet](because x in EmptySet is FALSE for all x).
+    '''
+    from . import empty_set_contradiction
+    if elem is None:
+        elem = x
+    extended_assumptions = defaults.assumptions + (claim_to_deny,)
+    contradiction = empty_set_contradiction.instantiate(
+            {x:elem}, assumptions = extended_assumptions)
+    contradiction_as_impl = contradiction.as_implication(claim_to_deny)
+    return contradiction_as_impl.deny_antecedent(
+            assumptions = extended_assumptions)

--- a/packages/proveit/logic/sets/membership/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/logic/sets/membership/_theory_nbs_/demonstrations.ipynb
@@ -16,12 +16,13 @@
    "source": [
     "import proveit\n",
     "from proveit import ExprTuple, InstantiationFailure, ProofFailure, UnsatisfiedPrerequisites\n",
-    "from proveit.logic import (Forall, Equals, EvaluationError, InSet, Not, NotEquals,\n",
+    "from proveit.logic import (Forall, Equals, EvaluationError, Exists, InSet, Not, NotEquals,\n",
     "                           NotInSet, EmptySet, Set)\n",
     "from proveit import a, b, c, d, e, f, i, x, y, A, B, C, D, E, F, G, H, I, S, T, V\n",
     "from proveit.numbers import zero, one, two, three, four, five, six, seven, eight, nine, num, Exp\n",
-    "from proveit.numbers import Add, Integer, Mult, Natural, NaturalPos, Real, RealNeg, RealPos\n",
+    "from proveit.numbers import Add, Integer, Interval, Mult, Natural, NaturalPos, Real, RealNeg, RealPos\n",
     "from proveit.numbers.number_sets.number_set import NumberSet\n",
+    "\n",
     "%begin demonstrations"
    ]
   },
@@ -582,6 +583,77 @@
     "# But we should be able to shallow_evaluate with the appropriate assumption(s)\n",
     "InSet(a, Set(one, Add(one, three), three)).shallow_simplification(must_evaluate=True,\n",
     "                                                                  assumptions=[Equals(a, two)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `InSet.existential_side_effects()`\n",
+    "\n",
+    "This side-effects method is intended to be called from the Exists.side_effects() method, but we engineer an explicit test of the `existential_side_effects()` method here. Essentially: Given an existential set membership claim, such as $\\exists_{x}\\big(x \\in A\\big)$, we can conclude as a side-effect that set $A$ is non-empty."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exists_x_in_1_to_3 = Exists(x, InSet(x, Interval(one, three)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exists_x_in_1_to_3_judgment = exists_x_in_1_to_3.conclude_via_example(one)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for side_effect in exists_x_in_1_to_3_judgment.instance_expr.existential_side_effects(exists_x_in_1_to_3_judgment):\n",
+    "    display(side_effect())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now, demonstrating the effect _implicitly_:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exists_x_in_2_to_5 = Exists(x, InSet(x, Interval(two, five)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exists_x_in_2_to_5_judgment = exists_x_in_2_to_5.conclude_via_example(two)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NotEquals(exists_x_in_2_to_5.instance_expr.domain, EmptySet).prove()"
    ]
   },
   {

--- a/packages/proveit/logic/sets/membership/in_set.py
+++ b/packages/proveit/logic/sets/membership/in_set.py
@@ -1,7 +1,7 @@
-from proveit import (Literal, Operation, defaults, USE_DEFAULTS,
-                     ProofFailure, UnusableProof,
-                     single_or_composite_expression,
-                     prover, equality_prover, relation_prover)
+from proveit import (
+        defaults, equality_prover, Judgment, Literal, Operation,
+        ProofFailure, prover, relation_prover, single_or_composite_expression,
+        UnusableProof, USE_DEFAULTS)
 from proveit.util import OrderedSet
 from proveit.relations import Relation
 from proveit.classes import ClassMembership
@@ -100,6 +100,51 @@ class InSet(Relation):
             for side_effect in self.membership_object.side_effects(
                     judgment):
                 yield side_effect
+
+    def existential_side_effects(self, judgment):
+        '''
+        This method is intended to be called from Exists.side_effects()
+        for an Exists.instance_expr with a 'not_equals_side_effects'
+        attribute. For a judgment or assumption of the form
+
+           Exists(x, x in A),
+
+        derive the NotEquals Judgment:
+
+          |- NotEquals(A, EmptySet)
+
+        (i.e., if there exists an element x in A, then A must be
+        non-empty).
+        This side-effect method is called from Exists.side_effects().
+        Future development might also call this method from the InSet.
+        side_effects() method itself.
+        '''
+
+        from . import InSet
+        from proveit.logic import Exists
+        if not isinstance(judgment, Judgment):
+            raise ValueError(
+                    "InSet.existential_side_effects() expecting 'judgment' "
+                    f"argument to be Judgment but got {judgment}.")
+        if not isinstance(judgment.expr, (Exists, InSet)):
+            raise ValueError(
+                    "InSet.existential_side_effects() expecting "
+                    "'judgment' expr to be an Exists or InSet "
+                    f"but got {judgment}.")
+        if (isinstance(judgment.expr, Exists) and
+            not isinstance(judgment.expr.instance_expr, InSet)):
+            raise ValueError(
+                    "InSet.existential_side_effects() expecting "
+                    "'judgment' expr to be an Exists expr with an"
+                    "InSet instance_expr, but got judgment: "
+                    f"{judgment}.")
+        if not judgment.expr.instance_params.is_single():
+            return
+
+        from proveit import A
+        from proveit.logic.sets import non_empty_folding
+        _A_sub = judgment.expr.instance_expr.domain
+        yield (lambda : non_empty_folding.instantiate({A:_A_sub}))
 
     @equality_prover('defined', 'define')
     def definition(self, **defaults_config):

--- a/packages/proveit/numbers/number_sets/integers/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/numbers/number_sets/integers/_theory_nbs_/demonstrations.ipynb
@@ -117,7 +117,77 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Some Example Domains For Testing"
+    "#### Testing `Interval()` Simplification for vacuous/empty or singleton Intervals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "one_to_three_interval = Interval(one, three)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "three_to_one_interval = Interval(three, one)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "one_to_three_interval.simplification()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "three_to_one_interval.simplification()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Interval(a, b).simplification(assumptions=[InSet(a, Integer), InSet(b, Integer), Less(b, a)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Interval(a, b).simplification(assumptions=[InSet(a, Integer), InSet(b, Integer), Equals(b, a)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Interval(two, two).simplification()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Some Example Domains For Testing"
    ]
   },
   {
@@ -134,7 +204,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Some Example Membership Claims For Testing"
+    "#### Some Example Membership Claims For Testing"
    ]
   },
   {

--- a/packages/proveit/numbers/number_sets/integers/_theory_nbs_/proofs/singleton_interval/thm_proof.ipynb
+++ b/packages/proveit/numbers/number_sets/integers/_theory_nbs_/proofs/singleton_interval/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">numbers</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">number_sets</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">integers</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#singleton_interval\">singleton_interval</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving singleton_interval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/numbers/number_sets/integers/_theory_nbs_/theorems.ipynb
+++ b/packages/proveit/numbers/number_sets/integers/_theory_nbs_/theorems.ipynb
@@ -318,6 +318,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "singleton_interval = Forall((a, b), Equals(Interval(a, b), Set(a)), conditions=[Equals(a, b)], domain=Integer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "in_interval = Forall((a, b, n), InSet(n, Interval(a, b)), domain=Integer, \n",
     "                    conditions=[number_ordering(LessEq(a, n), LessEq(n, b))])"
    ]

--- a/packages/proveit/numbers/number_sets/integers/interval.py
+++ b/packages/proveit/numbers/number_sets/integers/interval.py
@@ -1,11 +1,10 @@
-from proveit import Literal, Operation, prover
+from proveit import (
+        equality_prover, Literal, Operation, prover,
+        SimplificationDirectives, TransRelUpdater)
 from proveit import a, b, c, d, n, x
 
 
 class Interval(Operation):
-    # operator of the Interval operation.
-    _operator_ = Literal(string_format='Interval', theory=__file__)
-
     r'''
     The Interval class represents a set of of contiguous integers,
     from lower_bound to upper_bound (inclusively). For example:
@@ -13,7 +12,23 @@ class Interval(Operation):
     represents the integer set {2, 3, 4, 5, 6}. Once created, the
     resulting Interval is interpreted as a SET of elements with no
     assurances about the elements being in a particular order.
+
+    Default simplification directives will typically lead to routine
+    simplification of Intervals in the following ways:
+    • Interval(a, b), where b < a, will simplified to the empty set
+      (EmptySet). Such expressions might be created directly by the
+      user or might arise as variables a and b take on different
+      values in some processing context.
+    • Interval(a, b), where a = b, will be simplified to the singleton
+      enumerated set Set(a) = {a}.
+
     '''
+
+    # operator of the Interval operation.
+    _operator_ = Literal(string_format='Interval', theory=__file__)
+
+    _simplification_directives_ = SimplificationDirectives(
+            reduce_vacuous=True, reduce_single=True)
 
     def __init__(self, lower_bound, upper_bound, *, styles=None):
         Operation.__init__(self, Interval._operator_,
@@ -37,6 +52,50 @@ class Interval(Operation):
         from .interval_membership import IntervalNonmembership
         return IntervalNonmembership(element, self)
 
+    @equality_prover('shallow_simplified', 'shallow_simplify')
+    def shallow_simplification(self, *, must_evaluate=False,
+                               **defaults_config):
+        '''
+        Returns a proven simplification equation for this Interval
+        expression, using any specified simplification diretives,
+        as follows:
+
+        (1) If simplification directive reduce_vacuous = True, an
+            empty Interval(a, b), indicated when b < a, is reduced
+            to the empty set (Prove-It's EmptySet);
+
+        (2) If simplification directive reduce_single = True, a
+            single-element such as Interval(a, a) is reduced to
+            an enumerated set Set(a).
+
+        Otherwise returning the equality self = self.
+        '''
+
+        from proveit.logic import Equals
+        from proveit.numbers import Less
+
+        # For convenience in updating our equation, beginning with
+        # self = self
+        eq = TransRelUpdater(self)
+
+        
+        _lower_bound = self.lower_bound
+        _upper_bound = self.upper_bound
+
+        # Empty Interval:  Interval(a, b) with b < a
+        if Less(_upper_bound, _lower_bound).readily_provable():
+            from . import vacuous_interval
+            return vacuous_interval.instantiate(
+                {a:_lower_bound, b:_upper_bound})
+
+        # Singleton Interval: Interval(a, b) with a = b
+        if Equals(_upper_bound, _lower_bound).readily_provable():
+            from . import singleton_interval
+            return singleton_interval.instantiate(
+                {a:_lower_bound, b:_upper_bound})
+
+        return eq.relation # Might simply be self = self
+
     def readily_includes(self, other_set):
         '''
         Return True if this NumberSet includes the 'other_set' set.
@@ -53,7 +112,7 @@ class Interval(Operation):
 
     @prover
     def deduce_subset_eq_relation(self, sub_interval, **defaults_config):
-        '''
+        r'''
         Deduce that self of the form {a...d} has as a subset_eq the
         Interval of the form {b...c}, if a <= b <= c <= d. Example:
             {1...5}.deduce_subset_eq_relation({2...4})


### PR DESCRIPTION
This branch focuses on two related but independent "upgrades," focusing on (1) Interval.shallow_simplification, and (2) an EmptySetMembership class.

(1) The branch provides a simple implementation of Interval.shallow_simplification(), focusing on the simplification of (a) empty intervals of the form Interval(a, b) with b < a, simplifying such intervals to the EmptySet, and (b) singleton intervals of the form Interval(a,a), simplifying such intervals to a singleton set Set(a) = {a}.

(2) The branch also provides simple implementations of EmptySetMembership and EmptySetNonmembership classes and some related methods, as well as two module-level functions in the empty_set_membership.py code: `affirm_via_empty_set_contradiction()` and `deny_via_empty_set_contradiction()`.

One major goal of these modifications is to then allow related updates to the SetOfAll class so that a set comprehension on an empty domain can be easily reduced to an empty set. Modifications to the SetOfAll class and related methods might themselves probably be implemented, though, in a separate branch. I need to check on earlier work done on the SetOfAll class and related methods.