### PR TITLE
383 kronecker delta eval

### DIFF
--- a/packages/proveit/numbers/exponentiation/exp.py
+++ b/packages/proveit/numbers/exponentiation/exp.py
@@ -5,7 +5,7 @@ from proveit import (defaults, equality_prover, ExprRange, ExprTuple,
                      ProofFailure, prover, relation_prover, StyleOptions,
                      UnsatisfiedPrerequisites, USE_DEFAULTS)
 import proveit
-from proveit import a, b, c, d, k, m, n, r, x, y, S, theta
+from proveit import a, b, c, d, i, j, k, m, n, r, x, y, S, theta
 from proveit.logic import Equals, InSet, SetMembership, NotEquals
 from proveit.numbers import zero, one, two, Div, frac, num, greater_eq
 from proveit.numbers import (NumberOperation, deduce_number_set,
@@ -280,7 +280,7 @@ class Exp(NumberOperation):
         from proveit.numbers import (zero, one, two, Add, Neg, Mult, Div,
                                      is_numeric_int, is_numeric_rational,
                                      numeric_rational_ints,
-                                     Log, Rational, Abs)
+                                     Log, Rational, Abs, KroneckerDelta)
         from . import (exp_zero_eq_one, exponentiated_zero,
                        exponentiated_one, exp_nat_pos_expansion)
 
@@ -415,6 +415,14 @@ class Exp(NumberOperation):
                 return self.double_exponent_reduction()
             except:
                 pass # number sets not proper
+        elif (isinstance(base, KroneckerDelta)
+              and InSet(exponent, RealPos).readily_provable()):
+            from proveit.numbers.functions import kron_delta_power_reduction
+            _i_sub = base.operands[0]
+            _j_sub = base.operands[1]
+            _n_sub = exponent
+            return kron_delta_power_reduction.instantiate(
+                    {i:_i_sub, j:_j_sub, n:_n_sub})
         if Exp._simplification_directives_.distribute_exponent and (
                 isinstance(base, Mult) or isinstance(base, Div)):
             # Distribute the exponent as directed.

--- a/packages/proveit/numbers/functions/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/demonstrations.ipynb
@@ -87,6 +87,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`KroneckerDelta.readily_provable_number_set()` returns the most restrictive _standard_ number set we can readily prove contains the evaluation of the `KroneckerDelta` expression:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -111,6 +118,41 @@
    "outputs": [],
    "source": [
     "KroneckerDelta(zero, one).readily_provable_number_set()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We should be able to prove automatically that `KroneckerDelta(i,j)` is an element of various different standard sets (depending on the values of $i$ and $j$):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit.numbers import (Integer, IntegerNeg, IntegerNonZero, Natural, NaturalPos,\n",
+    "                             Real, RealNonNeg, RealNonZero, RealPos, ZeroSet)\n",
+    "display(InSet(KroneckerDelta(i, j), Natural).prove())\n",
+    "display(InSet(KroneckerDelta(i, j), NaturalPos).prove(assumptions=[Equals(i, j)]))\n",
+    "display(InSet(KroneckerDelta(i, j), ZeroSet).prove(assumptions=[NotEquals(i, j)]))\n",
+    "display(InSet(KroneckerDelta(i, j), Integer).prove(assumptions=[NotEquals(i, j)]))\n",
+    "display(InSet(KroneckerDelta(i, j), Real).prove())\n",
+    "display(InSet(KroneckerDelta(i, j), RealNonNeg).prove())\n",
+    "display(InSet(KroneckerDelta(i, j), RealPos).prove(assumptions=[Equals(i, j)]))\n",
+    "display(InSet(KroneckerDelta(i, j), RealNonZero).prove(assumptions=[Equals(i, j)]))\n",
+    "# when i is simply not known to be equal to j, but we try ZeroSet anyway\n",
+    "try:\n",
+    "    display(InSet(KroneckerDelta(i, j), ZeroSet).prove())\n",
+    "except Exception as the_exception:\n",
+    "    print(f\"EXCEPTION: {the_exception}\")\n",
+    "# when we try to deduce an illegitimate number set\n",
+    "try:\n",
+    "    display(InSet(KroneckerDelta(i, j), IntegerNeg).prove())\n",
+    "except Exception as the_exception:\n",
+    "    print(f\"EXCEPTION: {the_exception}\")"
    ]
   },
   {

--- a/packages/proveit/numbers/functions/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/demonstrations.ipynb
@@ -264,7 +264,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "example_set_mod_01 = example_set.inner_expr().domain.lower_bound.substitution(sub_eq_0, assumptions=[Equals(t, zero)])"
+    "Equals(t, zero).substitution(example_set, assumptions=[Equals(t, zero), InSet(n, NaturalPos)], preserve_expr=example_set)"
    ]
   },
   {
@@ -273,51 +273,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sub_eq_2 = Equals(t, zero).prove(assumptions=[Equals(t, zero)])\n",
-    "example_set_mod_02 = (\n",
-    "        example_set_mod_01.inner_expr().rhs.domain.upper_bound.operands[1].operand.substitute(\n",
-    "        sub_eq_2, assumptions=[Equals(t, zero)]).inner_expr().rhs.domain.upper_bound.simplify(assumptions=[InSet(n, NaturalPos)]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sub_eq_3 = Equals(ExprTuple(zero, l, t), ExprTuple(zero, l, zero)).prove(assumptions=[Equals(t, zero)])\n",
-    "example_set_mod_02.inner_expr().rhs.instance_expr.substitute(sub_eq_3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "example_set_simp_01 = (\n",
-    "    example_set.inner_expr().domain.lower_bound.operands[1].operand.simplification(assumptions=[Equals(t, one)]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "example_set_simp_02 = example_set_simp_01.inner_expr().rhs.domain.lower_bound.simplify()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "replacement_eq = Equals(t, one).prove(assumptions=[Equals(t, one)])\n",
-    "example_set_simp_03 = (\n",
-    "    example_set_simp_02.inner_expr().rhs.domain.upper_bound.operands[1].operand.substitute(\n",
-    "        replacement_eq, assumptions=[InSet(n, NaturalPos)]))"
+    "Equals(t, one).substitution(example_set, assumptions=[Equals(t, one), InSet(n, NaturalPos)], preserve_expr=example_set)"
    ]
   },
   {

--- a/packages/proveit/numbers/functions/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/demonstrations.ipynb
@@ -15,12 +15,13 @@
    "outputs": [],
    "source": [
     "import proveit\n",
-    "from proveit import Lambda\n",
-    "from proveit import l, x\n",
-    "from proveit.logic import InSet\n",
-    "from proveit.numbers.functions import IsMonDecFunc\n",
-    "from proveit.numbers import Div, Exp\n",
-    "from proveit.numbers import one, two, RealPos\n",
+    "from proveit import a, b, i, j, l, n, t, x, ExprTuple, Lambda\n",
+    "from proveit.logic import Equals, InSet, NotEquals\n",
+    "from proveit.logic.sets import SetOfAll\n",
+    "from proveit.numbers import (\n",
+    "        zero, one, two, Exp, Interval, KroneckerDelta, Less, num,\n",
+    "        NaturalPos, subtract)\n",
+    "\n",
     "%begin demonstrations"
    ]
   },
@@ -44,6 +45,308 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Misc. Constructions and Testing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### `KroneckerDelta` $\\delta_{i,j}$: Basic Constructions & Methods"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(i, j)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(i, j).commutation()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Kronecker delta is generally idempotent\n",
+    "Exp(KroneckerDelta(i, j), n).simplification(assumptions = [InSet(n, NaturalPos)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(i, j).readily_provable_number_set()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(one, one).readily_provable_number_set()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(zero, one).readily_provable_number_set()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(i, j).deduce_image_set()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(one, one).deduce_image_set()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(zero, one).deduce_image_set()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(i, j).deduce_bounds()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(i, j).simplification()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(i, j).simplification(assumptions=[Equals(i, j)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(zero, zero).simplification()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(zero, one).simplification()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(two, one).simplification()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(t, zero).simplification(assumptions=[Equals(t, zero)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "KroneckerDelta(t, zero).simplification(assumptions=[Equals(t, one)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_set = SetOfAll(l, ExprTuple(zero, l, t),\n",
+    "            domain=Interval(subtract(one, KroneckerDelta(t, zero)), subtract(subtract(n, one), t)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "one_minus_delta = Equals(subtract(one, KroneckerDelta(t, zero)), subtract(one, KroneckerDelta(t, zero))).prove()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sub_eq_0 = one_minus_delta.inner_expr().rhs.operands[1].operand.simplify(assumptions=[Equals(t, zero)]).inner_expr().rhs.simplify()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sub_eq_1 = one_minus_delta.inner_expr().rhs.operands[1].operand.simplify(assumptions=[Equals(t, one)]).inner_expr().rhs.simplify()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_set_mod_01 = example_set.inner_expr().domain.lower_bound.substitution(sub_eq_0, assumptions=[Equals(t, zero)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sub_eq_2 = Equals(t, zero).prove(assumptions=[Equals(t, zero)])\n",
+    "example_set_mod_02 = (\n",
+    "        example_set_mod_01.inner_expr().rhs.domain.upper_bound.operands[1].operand.substitute(\n",
+    "        sub_eq_2, assumptions=[Equals(t, zero)]).inner_expr().rhs.domain.upper_bound.simplify(assumptions=[InSet(n, NaturalPos)]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sub_eq_3 = Equals(ExprTuple(zero, l, t), ExprTuple(zero, l, zero)).prove(assumptions=[Equals(t, zero)])\n",
+    "example_set_mod_02.inner_expr().rhs.instance_expr.substitute(sub_eq_3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_set_simp_01 = (\n",
+    "    example_set.inner_expr().domain.lower_bound.operands[1].operand.simplification(assumptions=[Equals(t, one)]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_set_simp_02 = example_set_simp_01.inner_expr().rhs.domain.lower_bound.simplify()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "replacement_eq = Equals(t, one).prove(assumptions=[Equals(t, one)])\n",
+    "example_set_simp_03 = (\n",
+    "    example_set_simp_02.inner_expr().rhs.domain.upper_bound.operands[1].operand.substitute(\n",
+    "        replacement_eq, assumptions=[InSet(n, NaturalPos)]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Testing KroneckerDelta evaluation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit.numbers.functions import kron_delta_def\n",
+    "kron_delta_def"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kron_delta_def.instantiate({i:a, j:b}, assumptions=[Equals(a, b)], preserve_expr=KroneckerDelta(a, b))"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -62,7 +365,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   }

--- a/packages/proveit/numbers/functions/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/demonstrations.ipynb
@@ -228,7 +228,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "one_minus_delta = Equals(subtract(one, KroneckerDelta(t, zero)), subtract(one, KroneckerDelta(t, zero))).prove()"
+    "one_minus_delta = subtract(one, KroneckerDelta(t, zero))"
    ]
   },
   {
@@ -237,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sub_eq_0 = one_minus_delta.inner_expr().rhs.operands[1].operand.simplify(assumptions=[Equals(t, zero)]).inner_expr().rhs.simplify()"
+    "Equals(t, zero).substitution(one_minus_delta, assumptions=[Equals(t, zero)], preserve_expr=one_minus_delta)"
    ]
   },
   {
@@ -246,7 +246,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sub_eq_1 = one_minus_delta.inner_expr().rhs.operands[1].operand.simplify(assumptions=[Equals(t, one)]).inner_expr().rhs.simplify()"
+    "Equals(t, one).substitution(one_minus_delta, assumptions=[Equals(t, one)], preserve_expr=one_minus_delta)"
    ]
   },
   {

--- a/packages/proveit/numbers/functions/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/demonstrations.ipynb
@@ -345,6 +345,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Testing a Special Interval Membership Involving the Kronecker Delta Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit import i, l, n\n",
+    "from proveit.numbers import subtract, zero\n",
+    "_lower_bound, _upper_bound = (\n",
+    "        subtract(one, KroneckerDelta(i, zero)),\n",
+    "        subtract(subtract(n, one), i).simplification(assumptions=[InSet(i, Natural), InSet(n, Natural)]).rhs\n",
+    ")\n",
+    "_example_interval = Interval(_lower_bound, _upper_bound)\n",
+    "InSet(l, _example_interval).prove(assumptions=[InSet(l, _example_interval)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_bounds/thm_proof.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_bounds/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">numbers</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">functions</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#kron_delta_bounds\">kron_delta_bounds</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving kron_delta_bounds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_commutation/thm_proof.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_commutation/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">numbers</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">functions</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#kron_delta_commutation\">kron_delta_commutation</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving kron_delta_commutation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_eq_in_nat_pos/thm_proof.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_eq_in_nat_pos/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">numbers</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">functions</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#kron_delta_eq_in_nat_pos\">kron_delta_eq_in_nat_pos</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving kron_delta_eq_in_nat_pos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_image/thm_proof.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_image/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">numbers</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">functions</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#kron_delta_image\">kron_delta_image</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving kron_delta_image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_in_natural/thm_proof.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_in_natural/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">numbers</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">functions</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#kron_delta_in_natural\">kron_delta_in_natural</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving kron_delta_in_natural"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_neq_in_zero_set/thm_proof.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_neq_in_zero_set/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">numbers</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">functions</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#kron_delta_neq_in_zero_set\">kron_delta_neq_in_zero_set</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving kron_delta_neq_in_zero_set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_power_reduction/thm_proof.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/proofs/kron_delta_power_reduction/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">numbers</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">functions</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#kron_delta_power_reduction\">kron_delta_power_reduction</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving kron_delta_power_reduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/numbers/functions/_theory_nbs_/theorems.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/theorems.ipynb
@@ -98,6 +98,38 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from proveit.numbers import Natural\n",
+    "kron_delta_in_natural = (Forall((i, j), InSet(KroneckerDelta(i, j), Natural)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit.logic import NotEquals\n",
+    "from proveit.numbers import ZeroSet\n",
+    "kron_delta_neq_in_zero_set = (Forall((i, j), InSet(KroneckerDelta(i, j), ZeroSet), conditions=[NotEquals(i, j)]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit.logic import Equals\n",
+    "from proveit.numbers import NaturalPos\n",
+    "kron_delta_eq_in_nat_pos = (Forall((i, j), InSet(KroneckerDelta(i, j), NaturalPos), conditions=[Equals(i, j)]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "%end theorems"
    ]
   }

--- a/packages/proveit/numbers/functions/_theory_nbs_/theorems.ipynb
+++ b/packages/proveit/numbers/functions/_theory_nbs_/theorems.ipynb
@@ -17,9 +17,10 @@
     "import proveit\n",
     "# Prepare this notebook for defining the theorems of a theory:\n",
     "%theorems_notebook # Keep this at the top following 'import proveit'.\n",
-    "from proveit import x, Lambda\n",
-    "from proveit.logic import InSet\n",
-    "from proveit.numbers import one, two, Div, Exp, IsMonDecFunc, RealPos\n",
+    "from proveit import i, j, n, x, Lambda\n",
+    "from proveit.logic import Equals, Forall, InSet\n",
+    "from proveit.logic.sets import Set\n",
+    "from proveit.numbers import zero, one, two, Div, Exp, IsMonDecFunc, KroneckerDelta, RealPos\n",
     "# from ... import ..."
    ]
   },
@@ -48,13 +49,62 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "kron_delta_commutation = Forall((i, j), Equals(KroneckerDelta(i, j), KroneckerDelta(j, i)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Kronecker delta is generally idempotent: $(\\delta_{i,j})^{n} = \\delta_{i,j}$, since the exponentiation essentially ends up being applied to obtain $0^{n}$ or $1^{n}$. This means we are safe when $n \\in \\mathbb{R}^{+}$, but need to be careful when dealing with $n$ that might more generally be complex with a non-positive real component (including pure real that is non-positive). For our initial effort, we constrain the exponent to be positive Real:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kron_delta_power_reduction = (\n",
+    "    Forall((i, j),\n",
+    "      Forall(n, Equals(Exp(KroneckerDelta(i, j), n), KroneckerDelta(i, j)), domain = RealPos))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kron_delta_image = (Forall((i, j), InSet(KroneckerDelta(i, j), Set(zero, one))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proveit.numbers import LessEq, number_ordering\n",
+    "kron_delta_bounds = (\n",
+    "Forall((i, j), number_ordering(LessEq(zero, KroneckerDelta(i, j)), LessEq(KroneckerDelta(i, j), one)))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "%end theorems"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   }

--- a/packages/proveit/numbers/functions/delta.py
+++ b/packages/proveit/numbers/functions/delta.py
@@ -156,6 +156,7 @@ class KroneckerDelta(Operation):
                 return in_set
             # We must have proven we were in a subset of the
             # one we were looking for, so we take one more step.
+            from proveit.logic import InSet
             return InSet(self, number_set).prove()
 
         raise NotImplementedError(

--- a/packages/proveit/numbers/functions/delta.py
+++ b/packages/proveit/numbers/functions/delta.py
@@ -3,7 +3,9 @@ from proveit import (
         relation_prover, TransRelUpdater)
 from proveit.logic import Equals, is_irreducible_value, NotEquals
 from proveit.logic.sets import Set
-from proveit.numbers import zero, one, Natural, ZeroSet
+from proveit.numbers import (
+        zero, one, Integer, IntegerNonZero, Natural, NaturalPos, Real,
+        RealNonZero, RealNonNeg, RealPos, ZeroSet)
 
 class KroneckerDelta(Operation):
     '''
@@ -68,8 +70,6 @@ class KroneckerDelta(Operation):
 
         return eq.relation # Might simply be self=self.
 
-
-
     @equality_prover('commuted', 'commute')
     def commutation(self, **defaults_config):
         '''
@@ -95,6 +95,8 @@ class KroneckerDelta(Operation):
         if (is_irreducible_value(_i) and is_irreducible_value(_j)
            and _i != _j):
             return ZeroSet
+        if (_i == _j):
+            return NaturalPos
         return Natural
 
     def deduce_image_set(self, **defaults_config):
@@ -127,17 +129,36 @@ class KroneckerDelta(Operation):
     @relation_prover
     def deduce_in_number_set(self, number_set, **defaults_config):
         '''
-        Given a number set 'number_set', attempt to prove that the
-        given KroneckerDelta expression is in that number set.
-        Recall that KroneckerDelta in always in the set {0,1},
-        so this amounts to first deducing that this specific
+        Given a standard number set 'number_set', attempt to prove
+        that the given KroneckerDelta expression is in that number set.
+        Recall that KroneckerDelta in always in the set {0,1}, so the
+        process amounts to first deducing that this specific
         KroneckerDelta expression, which might actually be 0
-        or 1, or just in {0,1} more generally, is in a subset
-        of the provided number_set, then returning the desired
-        InSet() judgment.
+        or 1, or just in {0,1} more generally, is in ZeroSet, Natural,
+        or NaturalPos, then if necessary checking if that deduced set
+        is the desired set or a subset of the desired set.
         '''
-        from proveit.logic.sets import InSet, Set, SubsetEq
-        from proveit.numbers import zero, one
-        SubsetEq(self.deduce_image_set().rhs, number_set).prove()
-        return InSet(self, number_set).prove()
+        import proveit.numbers.functions as fxns_pkg
+        thm = None
+        if number_set == ZeroSet:
+            thm = fxns_pkg.kron_delta_neq_in_zero_set
+        if number_set in (IntegerNonZero, NaturalPos, RealNonZero, RealPos):
+            thm = fxns_pkg.kron_delta_eq_in_nat_pos
+        if number_set in (Natural, Integer, Real, RealNonNeg):
+            thm = fxns_pkg.kron_delta_in_natural
+
+        if thm is not None:
+            _i_sub = self.operands[0]
+            _j_sub = self.operands[1]
+            in_set = thm.instantiate({i:_i_sub, j:_j_sub})
+            if in_set.domain == number_set:
+                # Exactly the domain we were looking for.
+                return in_set
+            # We must have proven we were in a subset of the
+            # one we were looking for, so we take one more step.
+            return InSet(self, number_set).prove()
+
+        raise NotImplementedError(
+            f"'deduce_in_number_set() on {self} not implemented for "
+            f"the {number_set} set.")
 

--- a/packages/proveit/numbers/functions/delta.py
+++ b/packages/proveit/numbers/functions/delta.py
@@ -3,7 +3,7 @@ from proveit import (
         relation_prover, TransRelUpdater)
 from proveit.logic import Equals, is_irreducible_value, NotEquals
 from proveit.logic.sets import Set
-from proveit.numbers import zero, one
+from proveit.numbers import zero, one, Natural, ZeroSet
 
 class KroneckerDelta(Operation):
     '''
@@ -84,7 +84,7 @@ class KroneckerDelta(Operation):
 
     def readily_provable_number_set(self):
         '''
-        Return the most restrictive number set we can readily
+        Return the most restrictive standard number set we can readily
         prove contains the evaluation of this KroneckerDelta operation.
         If we have actual values for the arguments, we can return a
         singleton set {0} or {1}, otherwise we can return the two-elem
@@ -92,11 +92,10 @@ class KroneckerDelta(Operation):
         '''
         _i = self.operands[0]
         _j = self.operands[1]
-        if _i == _j: return Set(one)
         if (is_irreducible_value(_i) and is_irreducible_value(_j)
            and _i != _j):
-            return Set(zero)
-        return Set(zero, one)
+            return ZeroSet
+        return Natural
 
     def deduce_image_set(self, **defaults_config):
         '''

--- a/packages/proveit/numbers/functions/delta.py
+++ b/packages/proveit/numbers/functions/delta.py
@@ -1,5 +1,6 @@
 from proveit import (
-        i, j, x, y, equality_prover, Literal, Operation, TransRelUpdater)
+        i, j, x, y, equality_prover, Literal, Operation,
+        relation_prover, TransRelUpdater)
 from proveit.logic import Equals, is_irreducible_value, NotEquals
 from proveit.logic.sets import Set
 from proveit.numbers import zero, one
@@ -123,4 +124,21 @@ class KroneckerDelta(Operation):
         _i_sub = self.operands[0]
         _j_sub = self.operands[1]
         return kron_delta_bounds.instantiate({i:_i_sub, j:_j_sub})
+
+    @relation_prover
+    def deduce_in_number_set(self, number_set, **defaults_config):
+        '''
+        Given a number set 'number_set', attempt to prove that the
+        given KroneckerDelta expression is in that number set.
+        Recall that KroneckerDelta in always in the set {0,1},
+        so this amounts to first deducing that this specific
+        KroneckerDelta expression, which might actually be 0
+        or 1, or just in {0,1} more generally, is in a subset
+        of the provided number_set, then returning the desired
+        InSet() judgment.
+        '''
+        from proveit.logic.sets import InSet, Set, SubsetEq
+        from proveit.numbers import zero, one
+        SubsetEq(self.deduce_image_set().rhs, number_set).prove()
+        return InSet(self, number_set).prove()
 

--- a/packages/proveit/numbers/functions/delta.py
+++ b/packages/proveit/numbers/functions/delta.py
@@ -1,4 +1,8 @@
-from proveit import Operation, Literal
+from proveit import (
+        i, j, x, y, equality_prover, Literal, Operation, TransRelUpdater)
+from proveit.logic import Equals, is_irreducible_value, NotEquals
+from proveit.logic.sets import Set
+from proveit.numbers import zero, one
 
 class KroneckerDelta(Operation):
     '''
@@ -22,3 +26,101 @@ class KroneckerDelta(Operation):
     def latex(self, **kwargs):
         return (r'\delta_{' + self.operands[0].string(fence=True) + ', '
                          + self.operands[1].string(fence=True)) + '}'
+
+    @equality_prover('shallow_simplified', 'shallow_simplify')
+    def shallow_simplification(self, *, must_evaluate=False,
+                               **defaults_config):
+        '''
+        Return a proven simplification equation for this KroneckerDelta
+        expression assuming the operands have been simplified.
+        This mostly consists of evaluating the Kronecker delta function
+        d(i,j) for cases where we know that i = j or i ≠ j.
+        '''
+
+        from . import kron_delta_def, kron_delta_image
+        from proveit.logic.sets.enumeration import fold_singleton
+
+        expr = self
+        # For convenience in updating our equation
+        eq = TransRelUpdater(self)
+
+        _op_0 = self.operands[0]
+        _op_1 = self.operands[1]
+
+        # Calling NotEquals(_op_0, _op_1).readily_provable() further
+        # below misses some obvious cases, so we try a proof first
+        try:
+            NotEquals(_op_0, _op_1).prove()
+        except:
+            pass
+        
+        # Now we're ready to instantiate d(i,j) using the evaluation
+        # axiom for any of the following situations:
+        # (1) i == j;
+        # (2) i is readily provably equal to j;
+        # (3) i, j irreducible and not equal
+        if ((_op_0 == _op_1) or (Equals(_op_0, _op_1).readily_provable())
+            or (NotEquals(_op_0, _op_1).readily_provable()) or
+            (is_irreducible_value(_op_0) and is_irreducible_value(_op_1)
+                and _op_0 != _op_1)):
+            eq.update(kron_delta_def.instantiate({i:_op_0, j:_op_1}))
+
+        return eq.relation # Might simply be self=self.
+
+
+
+    @equality_prover('commuted', 'commute')
+    def commutation(self, **defaults_config):
+        '''
+        Deduce that this KroneckerDelta function expression delta(i,j)
+        is equal to the KroneckerDelta function in which the operands
+        have changed order: delta(j, i).
+        '''
+        from . import kron_delta_commutation
+        _i_sub = self.operands[0]
+        _j_sub = self.operands[1]
+        return kron_delta_commutation.instantiate({i:_i_sub, j:_j_sub})
+
+    def readily_provable_number_set(self):
+        '''
+        Return the most restrictive number set we can readily
+        prove contains the evaluation of this KroneckerDelta operation.
+        If we have actual values for the arguments, we can return a
+        singleton set {0} or {1}, otherwise we can return the two-elem
+        set {0, 1}.
+        '''
+        _i = self.operands[0]
+        _j = self.operands[1]
+        if _i == _j: return Set(one)
+        if (is_irreducible_value(_i) and is_irreducible_value(_j)
+           and _i != _j):
+            return Set(zero)
+        return Set(zero, one)
+
+    def deduce_image_set(self, **defaults_config):
+        '''
+        Deduce and return the set membership claim [self in {0,1}].
+        '''
+        from . import kron_delta_def, kron_delta_image
+        from proveit.logic.sets.enumeration import fold_singleton
+        _op_0 = self.operands[0]
+        _op_1 = self.operands[1]
+        if _op_0 == _op_1:
+            kron_delta_eval = kron_delta_def.instantiate({i:_op_0, j:_op_1})
+            return fold_singleton.instantiate({x:self, y:one})
+        if (is_irreducible_value(_op_0) and is_irreducible_value(_op_1)
+           and _op_0 != _op_1):
+            kron_delta_eval = kron_delta_def.instantiate({i:_op_0, j:_op_1})
+            return fold_singleton.instantiate({x:self, y:zero})
+
+        return kron_delta_image.instantiate({i:_op_0, j:_op_1})
+
+    def deduce_bounds(self, **defaults_config):
+        '''
+        Deduce and return the bounding claim that [0 ≤ self ≤ 1].
+        '''
+        from . import kron_delta_bounds
+        _i_sub = self.operands[0]
+        _j_sub = self.operands[1]
+        return kron_delta_bounds.instantiate({i:_i_sub, j:_j_sub})
+


### PR DESCRIPTION
This branch is ready for a review and some discussion. Changes here are motivated by the desire to use the Kronecker delta function in formulating representations of some vertex sets in the QEC branch.

This branch:
- Adds several basic theorems to the numbers/functions package related to the KroneckerDelta class;
- Adds several basic methods to the KroneckerDelta class, most notably a simple initial KroneckerDelta.shallow_simplification() method that seeks to reduce a $\delta_{i,j}$ expression to 1 or 0 when we know that i = j or that i ≠ j.
- Adds a case to Exp.shallow_simplification() to deal with special cases of $(\delta_{i,j})^{n}$ for $n$ a positive real.