### PR TITLE
385 expr tuple equality

### DIFF
--- a/packages/proveit/_core_/expression/composite/expr_tuple.py
+++ b/packages/proveit/_core_/expression/composite/expr_tuple.py
@@ -1149,9 +1149,79 @@ class ExprTuple(Composite, Expression):
             equality = equality.inner_expr().rhs.substitute(_b_orig)
         return equality
 
+    @prover
+    def deduce_equal_entries(self, other_tuple, **defaults_config):
+        '''
+        Given an other_tuple known or assumed to be equal to self,
+        deduce and return a conjunction of equalities between
+        corresponding entries. For example, 
+
+          (a,b,c).deduce_equal_entries((d,e,f),
+              assumptions=[Equals((a,b,c),(d,e,f))])
+
+        returns
+
+          {(a,b,c)=(d,e,f)} |- (a=d) AND (b=e) AND (c=f)
+
+        If (self = other_tuple) is not readily provable, raise an
+        error.
+        '''
+        from proveit import a, b, i, UnsatisfiedPrerequisites
+        from proveit.logic import Equals
+        from proveit.numbers import num
+
+        if Equals(self, other_tuple).readily_provable():
+            from proveit.core_expr_types.tuples import elem_eq_via_tuple_eq
+            _a_sub = self.entries
+            _b_sub = other_tuple.entries
+            _i_sub = num(self.num_entries())
+            return elem_eq_via_tuple_eq.instantiate(
+                    {i:_i_sub, a:_a_sub, b:_b_sub})
+        else:
+            raise UnsatisfiedPrerequisites(
+                    f"Error in applying ExprTuple.deduce_equal_entries(). "
+                    f"self = {self} not readily provably equal to "
+                    f"other_tuple = {other_tuple}, and thus equality "
+                    f"of corresponding entries cannot be deduced.")
+
+    @prover
+    def deduce_not_equal_entries(self, other_tuple, **defaults_config):
+        '''
+        Given an other_tuple known or assumed to be not equal to self,
+        deduce and return a disjunction of inequalities between
+        corresponding entries. For example, 
+
+          (a,b,c).deduce_equal_entries((d,e,f),
+              assumptions=[NotEquals((a,b,c),(d,e,f))])
+
+        returns
+
+          {(a,b,c)≠(d,e,f)} |- (a≠d) OR (b≠e) OR (c≠f)
+
+        If (self ≠ other_tuple) is not readily provable, raise an
+        error.
+        '''
+        from proveit import a, b, i, UnsatisfiedPrerequisites
+        from proveit.logic import NotEquals
+        from proveit.numbers import num
+
+        if NotEquals(self, other_tuple).readily_provable():
+            from proveit.core_expr_types.tuples import elem_neq_via_tuple_neq
+            _a_sub = self.entries
+            _b_sub = other_tuple.entries
+            _i_sub = num(self.num_entries())
+            return elem_neq_via_tuple_neq.instantiate(
+                    {i:_i_sub, a:_a_sub, b:_b_sub})
+        else:
+            raise UnsatisfiedPrerequisites(
+                    f"Error in applying ExprTuple.deduce_not_equal_entries(). "
+                    f"self = {self} not readily provably not equal to "
+                    f"other_tuple = {other_tuple}, and thus inequalities "
+                    f"of corresponding entries cannot be deduced.")
+
     @equality_prover('merged', 'merge')
     def merger(self, **defaults_config):
-        '''
+        r'''
         If this is an tuple of expressions that can be directly merged
         together into a single ExprRange, return this proven
         equivalence.  For example,

--- a/packages/proveit/_core_/expression/composite/expr_tuple.py
+++ b/packages/proveit/_core_/expression/composite/expr_tuple.py
@@ -1172,9 +1172,9 @@ class ExprTuple(Composite, Expression):
 
         if Equals(self, other_tuple).readily_provable():
             from proveit.core_expr_types.tuples import elem_eq_via_tuple_eq
-            _a_sub = self.entries
-            _b_sub = other_tuple.entries
-            _i_sub = num(self.num_entries())
+            _a_sub = self
+            _b_sub = other_tuple
+            _i_sub = self.num_elements()
             return elem_eq_via_tuple_eq.instantiate(
                     {i:_i_sub, a:_a_sub, b:_b_sub})
         else:
@@ -1202,15 +1202,16 @@ class ExprTuple(Composite, Expression):
         error.
         '''
         from proveit import a, b, i, UnsatisfiedPrerequisites
-        from proveit.logic import NotEquals
+        from proveit.logic import Equals, NotEquals
         from proveit.numbers import num
 
-        if (len(self)==len(other_tuple) and 
-            NotEquals(self, other_tuple).readily_provable()):
+        if (Equals(self.num_elements(),
+                   other_tuple.num_elements()).readily_provable()
+                and NotEquals(self, other_tuple).readily_provable()):
             from proveit.core_expr_types.tuples import elem_neq_via_tuple_neq
-            _a_sub = self.entries
-            _b_sub = other_tuple.entries
-            _i_sub = num(self.num_entries())
+            _a_sub = self
+            _b_sub = other_tuple
+            _i_sub = self.num_elements()
             return elem_neq_via_tuple_neq.instantiate(
                     {i:_i_sub, a:_a_sub, b:_b_sub})
         else:

--- a/packages/proveit/_core_/expression/composite/expr_tuple.py
+++ b/packages/proveit/_core_/expression/composite/expr_tuple.py
@@ -1205,7 +1205,8 @@ class ExprTuple(Composite, Expression):
         from proveit.logic import NotEquals
         from proveit.numbers import num
 
-        if NotEquals(self, other_tuple).readily_provable():
+        if (len(self)==len(other_tuple) and 
+            NotEquals(self, other_tuple).readily_provable()):
             from proveit.core_expr_types.tuples import elem_neq_via_tuple_neq
             _a_sub = self.entries
             _b_sub = other_tuple.entries
@@ -1213,11 +1214,19 @@ class ExprTuple(Composite, Expression):
             return elem_neq_via_tuple_neq.instantiate(
                     {i:_i_sub, a:_a_sub, b:_b_sub})
         else:
-            raise UnsatisfiedPrerequisites(
-                    f"Error in applying ExprTuple.deduce_not_equal_entries(). "
-                    f"self = {self} not readily provably not equal to "
-                    f"other_tuple = {other_tuple}, and thus inequalities "
-                    f"of corresponding entries cannot be deduced.")
+            if (len(self) != len(other_tuple)):
+                raise ValueError("ExprTuple.deduce_not_equal_entries() "
+                        f"does not apply to tuples of unequal length. "
+                        f"|{self}| = {len(self)} while |{other_tuple}| = "
+                        f"{len(other_tuple)}.")
+            else:
+                raise UnsatisfiedPrerequisites(
+                        "Error in applying "
+                        "ExprTuple.deduce_not_equal_entries(). "
+                        f"self = {self} not readily provably not equal "
+                        f"to other_tuple = {other_tuple}, and thus "
+                        "inequalities of corresponding entries cannot "
+                        "be deduced.")
 
     @equality_prover('merged', 'merge')
     def merger(self, **defaults_config):

--- a/packages/proveit/core_expr_types/tuples/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/core_expr_types/tuples/_theory_nbs_/demonstrations.ipynb
@@ -16,15 +16,15 @@
    "source": [
     "import proveit\n",
     "from proveit import (Lambda, ExprTuple, ExprRange, IndexedVar, safe_dummy_var,\n",
-    "                     defaults, Function, ProofFailure)\n",
-    "from proveit import A, a, b, c, d, e, f, g, i, j, k, l, m, n, x, y\n",
+    "                     defaults, Function, ProofFailure, var_range)\n",
+    "from proveit import A, a, b, c, d, e, f, g, i, j, k, l, m, n, x, y, z\n",
     "from proveit.logic import Equals, NotEquals, Not, EvaluationError, InSet\n",
     "from proveit.linear_algebra import TensorProd\n",
     "from proveit.numbers import (zero, one, two, three, four, e as e_nat, Add, Exp,\n",
     "                             Integer, Mult, Natural, NaturalPos, Neg, num, subtract)\n",
     "from proveit.core_expr_types import Len\n",
     "from proveit.core_expr_types import (\n",
-    "        a_i_to_j, x_1_to_n, y_1_to_n, f_i_to_j, f_i_to_jp1)\n",
+    "        a_i_to_j, b_1_to_k, x_1_to_n, y_1_to_n, f_i_to_j, f_i_to_jp1)\n",
     "from proveit.core_expr_types.tuples import (\n",
     "        len_of_ranges_with_repeated_indices_from_1, range_from1_len,\n",
     "        len_of_ranges_with_repeated_indices_from_1, len_of_ranges_with_repeated_indices,\n",
@@ -237,6 +237,38 @@
     "    ExprTuple(a, b, c).deduce_not_equal_entries(ExprTuple(d, e), assumptions=temp_assumptions)\n",
     "except Exception as the_exception:\n",
     "    print(f\"EXCEPTION: {the_exception}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And then similar demonstrations involving ExprTuples with embedded ExprRanges:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_1_to_k = var_range(y, one, k)\n",
+    "ExprTuple(a, b_1_to_k, c).deduce_equal_entries(\n",
+    "        ExprTuple(x, y_1_to_k, z),\n",
+    "        assumptions=[Equals(ExprTuple(a, b_1_to_k, c), ExprTuple(x, y_1_to_k, z)),\n",
+    "                     InSet(k, NaturalPos)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ExprTuple(a, b_1_to_k, c).deduce_not_equal_entries(\n",
+    "        ExprTuple(x, y_1_to_k, z),\n",
+    "        assumptions=[NotEquals(ExprTuple(a, b_1_to_k, c), ExprTuple(x, y_1_to_k, z)),\n",
+    "                     InSet(k, NaturalPos)])"
    ]
   },
   {

--- a/packages/proveit/core_expr_types/tuples/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/core_expr_types/tuples/_theory_nbs_/demonstrations.ipynb
@@ -17,7 +17,7 @@
     "import proveit\n",
     "from proveit import (Lambda, ExprTuple, ExprRange, IndexedVar, safe_dummy_var,\n",
     "                     defaults, Function, ProofFailure)\n",
-    "from proveit import A, a, b, f, g, i, j, k, l, m, n, x, y\n",
+    "from proveit import A, a, b, c, d, e, f, g, i, j, k, l, m, n, x, y\n",
     "from proveit.logic import Equals, NotEquals, Not, EvaluationError, InSet\n",
     "from proveit.linear_algebra import TensorProd\n",
     "from proveit.numbers import (zero, one, two, three, four, e as e_nat, Add, Exp,\n",
@@ -168,6 +168,62 @@
    "outputs": [],
    "source": [
     "eq.lhs.deduce_equal(eq.rhs, assumptions=[InSet(n, NaturalPos)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Equality (Inequality) of Tuples Means Equality (Inequality) of Entries:\n",
+    "#### `ExprTuple.deduce_equal_entries()` and `ExprTuple.deduce_not_equal_entries()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# with the necessary assumptions\n",
+    "temp_assumptions = [Equals(ExprTuple(a, b, c), ExprTuple(d, e, f))]\n",
+    "ExprTuple(a, b, c).deduce_equal_entries(ExprTuple(d, e, f), assumptions=temp_assumptions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# without the necessary assumptions\n",
+    "try:\n",
+    "    ExprTuple(a, b, c).deduce_equal_entries(ExprTuple(d, e, f))\n",
+    "except Exception as the_exception:\n",
+    "    print(f\"EXCEPTION: {the_exception}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# with the necessary assumptions\n",
+    "temp_assumptions = [NotEquals(ExprTuple(a, b, c), ExprTuple(d, e, f))]\n",
+    "ExprTuple(a, b, c).deduce_not_equal_entries(ExprTuple(d, e, f), assumptions=temp_assumptions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# without the necessary assumptions\n",
+    "try:\n",
+    "    ExprTuple(a, b, c).deduce_not_equal_entries(ExprTuple(d, e, f))\n",
+    "except Exception as the_exception:\n",
+    "    print(f\"EXCEPTION: {the_exception}\")"
    ]
   },
   {

--- a/packages/proveit/core_expr_types/tuples/_theory_nbs_/demonstrations.ipynb
+++ b/packages/proveit/core_expr_types/tuples/_theory_nbs_/demonstrations.ipynb
@@ -227,6 +227,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# without equal-length tuples\n",
+    "try:\n",
+    "    ExprTuple(a, b, c).deduce_not_equal_entries(ExprTuple(d, e), assumptions=temp_assumptions)\n",
+    "except Exception as the_exception:\n",
+    "    print(f\"EXCEPTION: {the_exception}\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/packages/proveit/core_expr_types/tuples/_theory_nbs_/proofs/elem_eq_via_tuple_eq/thm_proof.ipynb
+++ b/packages/proveit/core_expr_types/tuples/_theory_nbs_/proofs/elem_eq_via_tuple_eq/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">core_expr_types</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">tuples</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#elem_eq_via_tuple_eq\">elem_eq_via_tuple_eq</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving elem_eq_via_tuple_eq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/core_expr_types/tuples/_theory_nbs_/proofs/elem_neq_via_tuple_neq/thm_proof.ipynb
+++ b/packages/proveit/core_expr_types/tuples/_theory_nbs_/proofs/elem_neq_via_tuple_neq/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">core_expr_types</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">tuples</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#elem_neq_via_tuple_neq\">elem_neq_via_tuple_neq</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving elem_neq_via_tuple_neq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/core_expr_types/tuples/_theory_nbs_/proofs/tuple_equality_def/thm_proof.ipynb
+++ b/packages/proveit/core_expr_types/tuples/_theory_nbs_/proofs/tuple_equality_def/thm_proof.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Proof of <a class=\"ProveItLink\" href=\"../../../../../_theory_nbs_/theory.ipynb\">proveit</a>.<a class=\"ProveItLink\" href=\"../../../../_theory_nbs_/theory.ipynb\">core_expr_types</a>.<a class=\"ProveItLink\" href=\"../../theory.ipynb\">tuples</a>.<a class=\"ProveItLink\" href=\"../../theorems.ipynb#tuple_equality_def\">tuple_equality_def</a> theorem\n",
+    "========"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import proveit\n",
+    "theory = proveit.Theory() # the theorem's theory\n",
+    "from proveit import defaults, display_provers # useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%proving tuple_equality_def"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/packages/proveit/core_expr_types/tuples/_theory_nbs_/theorems.ipynb
+++ b/packages/proveit/core_expr_types/tuples/_theory_nbs_/theorems.ipynb
@@ -509,6 +509,52 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "tuple_equality_def = (\n",
+    "    Forall(i,\n",
+    "    Forall((a_1_to_i, b_1_to_i),\n",
+    "           Equals(Equals(ExprTuple(a_1_to_i), ExprTuple(b_1_to_i)),\n",
+    "           And(ExprRange(k, Equals(IndexedVar(a, k), IndexedVar(b, k)), one, i))).\n",
+    "               with_wrap_after_operator()),\n",
+    "    domain=NaturalPos)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elem_eq_via_tuple_eq = (\n",
+    "    Forall(i,\n",
+    "    Forall((a_1_to_i, b_1_to_i),\n",
+    "           And(ExprRange(k, Equals(IndexedVar(a, k), IndexedVar(b, k)), one, i)),\n",
+    "           conditions=[Equals(ExprTuple(a_1_to_i), ExprTuple(b_1_to_i))]),\n",
+    "    domain=NaturalPos)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elem_neq_via_tuple_neq = (\n",
+    "    Forall(i,\n",
+    "    Forall((a_1_to_i, b_1_to_i),\n",
+    "           Or(ExprRange(k, NotEquals(IndexedVar(a, k), IndexedVar(b, k)), one, i)),\n",
+    "           conditions=[NotEquals(ExprTuple(a_1_to_i), ExprTuple(b_1_to_i))]),\n",
+    "    domain=NaturalPos)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "tuple_elem_substitution = Forall((i, k), \n",
     "                      Forall((a_1_to_i, b, c_1_to_k, d),\n",
     "                             Equals([a_1_to_i, b, c_1_to_k], \n",


### PR DESCRIPTION
Related Issue #385 .
This branch introduces the following very limited changes to the core_expr_types/tuples package, motivated by a desired proof step in the QEC branch in which we want to use equal ExprTuples to conclude equal respective tuple entries:

- Adds three theorems for deducing equalities (inequalities) of entries via equalities (inequalities) of ExprTuples;
- Adds two methods to the ExprTuple class, to utilize the newly-introduced theorems. These methods will likely need more development eventually to deal with more complex ExprTuple cases.
- Updates the related demonstrations notebook to test and demo the use of the new methods.